### PR TITLE
OPHTUTU-31: Hakemuslistaus backendista

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/Controller.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/Controller.scala
@@ -2,7 +2,7 @@ package fi.oph.tutu.backend.controller
 
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import fi.oph.tutu.backend.domain.{Hakemus, UserResponse, HakemusOid}
+import fi.oph.tutu.backend.domain.{Hakemus, HakemusOid, UserResponse}
 import fi.oph.tutu.backend.repository.HakemusRepository
 import fi.oph.tutu.backend.service.{HakemuspalveluService, UserService}
 import fi.oph.tutu.backend.utils.{AuditLog, AuthoritiesUtil}
@@ -169,7 +169,7 @@ class Controller(
     val hakemusIdt: Seq[HakemusOid] = hakemusRepository.mockHaeHakemusIdt()
 
     // Datasisältöhaku eri palveluista (Ataru, TUTU, ...)
-    val ataruHakemukset: Seq[Any] = Seq[Any]()
+    val ataruHakemukset: Seq[Any]    = Seq[Any]()
     val tutuHakemukset: Seq[Hakemus] = hakemusRepository.haeHakemukset(hakemusIdt)
 
     // Yhdistetään tietolähteiden datat

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/Controller.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/Controller.scala
@@ -2,7 +2,7 @@ package fi.oph.tutu.backend.controller
 
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import fi.oph.tutu.backend.domain.{Hakemus, UserResponse}
+import fi.oph.tutu.backend.domain.{Hakemus, UserResponse, HakemusOid}
 import fi.oph.tutu.backend.repository.HakemusRepository
 import fi.oph.tutu.backend.service.{HakemuspalveluService, UserService}
 import fi.oph.tutu.backend.utils.{AuditLog, AuthoritiesUtil}
@@ -162,6 +162,21 @@ class Controller(
         LOG.error("Ataru-hakemuksen haku epäonnistui", e.getMessage)
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(RESPONSE_500_DESCRIPTION)
     }
+
+  @GetMapping(path = Array("hakemus"))
+  def listaaHakemukset(): String = {
+    // ElasticSearch-haku => palauttaa hakemusten ID:t
+    val hakemusIdt: Seq[HakemusOid] = hakemusRepository.mockHaeHakemusIdt()
+
+    // Datasisältöhaku eri palveluista (Ataru, TUTU, ...)
+    val ataruHakemukset: Seq[Any] = Seq[Any]()
+    val tutuHakemukset: Seq[Hakemus] = hakemusRepository.haeHakemukset(hakemusIdt)
+
+    // Yhdistetään tietolähteiden datat
+    val yhdistetytHakemukset = tutuHakemukset
+
+    mapper.writeValueAsString(yhdistetytHakemukset)
+  }
 
   // TODO: FOR TESTING, TO BE REMOVED LATERZ
   @GetMapping(path = Array("test"))

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusRepository.scala
@@ -95,14 +95,14 @@ class HakemusRepository {
    *   hakuehtojen mukaisten hakemusten Oid:t
    */
   def mockHaeHakemusIdt(): Seq[HakemusOid] =
-    try {
+    try
       db.run(
         sql"""
         SELECT hakemus_oid FROM hakemus
         """.as[HakemusOid],
         "mock_hae_hakemus_idt"
       )
-    } catch {
+    catch {
       case e: Exception =>
         throw new RuntimeException(
           s"Hakemuksien listaus epäonnistui: ${e.getMessage}",

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/ControllerUnitTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/ControllerUnitTest.scala
@@ -109,4 +109,42 @@ class ControllerUnitTest {
       )
       .andExpect(status().isNotFound)
   }
+
+  @Test
+  @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
+  def haeHakemuslistaReturns200AndArrayOfItems(@Autowired mvc: MockMvc): Unit = {
+
+    when(
+      hakemusRepository.mockHaeHakemusIdt()
+    ).thenReturn(
+      Seq(
+        HakemusOid("1"),
+        HakemusOid("2"),
+        HakemusOid("3")
+      )
+    )
+
+    when(
+      hakemusRepository.haeHakemukset(any)
+    ).thenReturn(
+      Seq(
+        Hakemus(HakemusOid("1")),
+        Hakemus(HakemusOid("2")),
+        Hakemus(HakemusOid("3"))
+      )
+    )
+
+    when(hakemuspalveluService.toString).thenCallRealMethod()
+    when(userService.toString).thenCallRealMethod()
+    when(auditLog.toString).thenCallRealMethod()
+
+    mvc
+      .perform(
+        get("/api/hakemus")
+      )
+      .andExpect(status().isOk)
+      .andExpect(jsonPath("$[0].hakemusOid.s").value("1"))
+      .andExpect(jsonPath("$[1].hakemusOid.s").value("2"))
+      .andExpect(jsonPath("$[2].hakemusOid.s").value("3"))
+  }
 }


### PR DESCRIPTION
- Controllerissa ElasticSearch-hakua mukaileva rakenne
- Repositoryssä funktio hakemusdatan hakemiseen Oid:n perusteella
- Repositoryssa myös ElasticSearch-hakua mukaileva placeholder-toteutus

---

Hakemuslistauksen toteutus mukailee ElasticSearch-prosessia nyky-ymmärryksemme mukaan:

1. Haun ensimmäisessä vaiheessa hakuehdot syötetään ES:lle, joka tuottaa listan hakemusten Oid:tä. Tämä vaihe on toteutettu pikaisella placeholder-toteutuksella, jonka tiedetään muuttuvan. Nykytoteutus ei rajaa hakutuloksia vaan palauttaa kaikki hakemukset kannasta.
2. Haun toisessa vaiheessa haetaan eri tietolähteistä hakemusten data ja yhdistetään ne hakemuslistausrajapinnan tarpeiden mukaan. Nykytoteutus hakee tietoja vain TUTU-kannasta ja palauttaa sen sellaisenaan clientille.