### PR TITLE
OPHTUTU-60: Lisätty hakemuksen sisältö perustietosivulle

### DIFF
--- a/tutu-frontend/src/app/(root)/hakemus/[oid]/components/Sisalto.tsx
+++ b/tutu-frontend/src/app/(root)/hakemus/[oid]/components/Sisalto.tsx
@@ -1,0 +1,80 @@
+import { Fragment } from 'react';
+import { OphTypography } from '@opetushallitus/oph-design-system';
+import { SisaltoItem } from '@/src/lib/types/hakemus';
+import * as R from 'remeda';
+import { styled } from '@mui/material';
+
+const Indented = styled((props) => (
+  <div {...props} className={`${props.className} indented`} />
+))({
+  //backgroundColor: `#0033cc11`,
+  '.indented .indented': {
+    paddingLeft: `1em`,
+  },
+  '.indented:last-child': {
+    paddingBottom: `24px`,
+  },
+});
+
+const EntryLabel = styled((props) => (
+  <OphTypography variant={'label'} {...props} />
+))({
+  display: 'block',
+});
+
+const EntryValue = styled((props) => (
+  <OphTypography variant={'body 1'} {...props} />
+))({
+  paddingLeft: `1em`,
+  display: 'block',
+});
+
+const Subsection = styled('div')({
+  paddingLeft: `1em`,
+  display: 'block',
+});
+
+export const Sisalto = ({
+  sisalto = [],
+  osiot = [],
+}: {
+  sisalto: SisaltoItem[];
+  osiot: string[];
+}) => {
+  return (
+    <div>
+      {sisalto
+        .filter((item) => osiot.includes(item.key))
+        .map((item) => renderItem(item))}
+    </div>
+  );
+};
+
+export const renderItem = (item: SisaltoItem) => {
+  const label = R.pathOr(item, ['label', 'fi'], null);
+  const renderedLabel =
+    label != null ? <EntryLabel>{label}</EntryLabel> : <></>;
+
+  const renderedValues = item.value.map((value) => (
+    <Fragment key={`${value.value}--item`}>
+      <EntryValue key={`${value.value}--value`}>
+        {`- ${R.pathOr(value, ['label', 'fi'], null)}`}
+      </EntryValue>
+      <Subsection key={`${value.value}--followups`}>
+        {value.followups.map(renderItem)}
+      </Subsection>
+    </Fragment>
+  ));
+
+  const renderedChildren = (
+    <Subsection>{item.children.map((child) => renderItem(child))}</Subsection>
+  );
+
+  return (
+    <Indented key={`${item.key}`}>
+      {renderedLabel}
+      {renderedValues}
+      {renderedChildren}
+    </Indented>
+  );
+};

--- a/tutu-frontend/src/app/(root)/hakemus/[oid]/perustiedot/page.tsx
+++ b/tutu-frontend/src/app/(root)/hakemus/[oid]/perustiedot/page.tsx
@@ -8,10 +8,18 @@ import { hakemusKoskeeOptions } from '@/src/constants/dropdownOptions';
 import { LabeledValue } from '@/src/app/(root)/hakemus/[oid]/components/LabeledValue';
 import { Muutoshistoria } from '@/src/app/(root)/hakemus/[oid]/perustiedot/Muutoshistoria';
 import { Henkilotiedot } from '@/src/app/(root)/hakemus/[oid]/perustiedot/Henkilotiedot';
+import { Sisalto } from '@/src/app/(root)/hakemus/[oid]/components/Sisalto';
 import { FullSpinner } from '@/src/components/FullSpinner';
 import useToaster from '@/src/hooks/useToaster';
 import { useEffect } from 'react';
 import { handleFetchError } from '@/src/lib/utils';
+
+const sisallonOsiot = [
+  '89e89dff-25b2-4177-b078-fcaf0c9d2589', // Tutkinto tai koulutus
+  '0d23f1d1-1aa5-4dcb-9234-28c593441935', // Päätös- ja asiointikieli
+  '3781f43c-fff7-47c7-aa7b-66f4a47395a5', // Päätöksen lähettäminen sähköpostilla
+  '9e94bfe6-5855-43fc-bd80-d5b74741decb', // Tietojen oikeellisuus ja todistusten aitous
+];
 
 export default function PerustietoPage() {
   const theme = useTheme();
@@ -46,6 +54,7 @@ export default function PerustietoPage() {
         label={t('hakemus.perustiedot.mitaHakee')}
         value={t(hakemusKoskee)}
       ></LabeledValue>
+      <Sisalto osiot={sisallonOsiot} sisalto={hakemus.sisalto} />
       <Stack gap={theme.spacing(3)} width={'60%'}>
         <Muutoshistoria muutosHistoria={hakemus.muutosHistoria} />
         <Henkilotiedot hakija={hakemus.hakija} />

--- a/tutu-frontend/src/lib/types/hakemus.ts
+++ b/tutu-frontend/src/lib/types/hakemus.ts
@@ -1,4 +1,5 @@
 import { Hakija } from '@/src/lib/types/hakija';
+import { Kielistetty } from '@/src/lib/types/common';
 
 export type MuutosHistoriaItem = {
   role: 'Esittelija' | 'Hakija' | 'Irrelevant';
@@ -19,4 +20,18 @@ export type Hakemus = {
   kasittelyVaihe: string;
   muokattu: string;
   muutosHistoria: MuutosHistoriaItem[];
+};
+
+export type SisaltoItem = {
+  key: string;
+  fieldType: string;
+  value: SisaltoValue[];
+  label: Kielistetty;
+  children: SisaltoItem[];
+};
+
+export type SisaltoValue = {
+  label: Kielistetty;
+  value: string;
+  followups: SisaltoItem[];
 };


### PR DESCRIPTION
Sisällön esittäminen tekstimuodossa käyttöliittymällä.

Jotkin arvot tulevat vaatimaan jälkikäsittelyä. Esimerkiksi liitetiedostot esitetään nyt niiden yksilöivän tunnuksen mukaan. Myöhemmin pitää tehdä liitetetiedoston linkitys vastauskentän tyypin mukaan.