### PR TITLE
OPHTUTU-235 Maajako page bugfixes

### DIFF
--- a/tutu-frontend/src/components/SelectedMaakoodiInfo.tsx
+++ b/tutu-frontend/src/components/SelectedMaakoodiInfo.tsx
@@ -32,7 +32,10 @@ export const SelectedMaakoodiInfo = ({
       return (
         <>
           <OphTypography variant={'h4'}>Esittelijä</OphTypography>
-          <OphTypography variant={'body1'}>
+          <OphTypography
+            variant={'body1'}
+            data-testid="selected-maakoodi-esittelija"
+          >
             {esittelija.etunimi} {esittelija.sukunimi}
           </OphTypography>
         </>


### PR DESCRIPTION
Esittelijälle osoitetut maat näytetään nyt aakkosjärjestyksessä myös lukunäkymässä (aiemmin viimeksi valittu maa jäi listan loppuun).
Kun maa siirretään toiselle esittelijälle, näkymä päivittyy automaattisesti ilman sivun uudelleenlatausta.