### PR TITLE
OPHTUTU-369: Korjauksia editoriin ja sen toimintoihin

### DIFF
--- a/tutu-frontend/src/app/hakemus/[oid]/editori/components/Editor.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/components/Editor.tsx
@@ -133,6 +133,7 @@ export function Editor({
                   ref={onRef}
                   style={{
                     position: 'relative',
+                    height: '100%',
                   }}
                 >
                   <ContentEditable
@@ -141,6 +142,7 @@ export function Editor({
                     style={{
                       padding: theme.spacing(1),
                       outline: 'none',
+                      height: '100%',
                     }}
                     aria-placeholder={''}
                     placeholder={<span>{''}</span>}

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/components/editor-utils.ts
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/components/editor-utils.ts
@@ -7,7 +7,11 @@ import {
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
+  BOLD_STAR,
+  LINK,
+  ORDERED_LIST,
   TRANSFORMERS,
+  UNORDERED_LIST,
 } from '@lexical/markdown';
 import { $isAtNodeEnd, $setBlocksType } from '@lexical/selection';
 import {
@@ -22,6 +26,8 @@ import {
   SKIP_SELECTION_FOCUS_TAG,
   TextNode,
 } from 'lexical';
+
+const MARKDOWN_TRANSFORMERS = [ORDERED_LIST, UNORDERED_LIST, LINK, BOLD_STAR];
 
 export const importHtml = (editor: LexicalEditor | null, html: string) => {
   if (editor) {
@@ -65,7 +71,7 @@ export const exportMarkdown = (editor: LexicalEditor | null) => {
   if (editor) {
     let content = '';
     editor.read(() => {
-      content = $convertToMarkdownString(TRANSFORMERS);
+      content = $convertToMarkdownString(MARKDOWN_TRANSFORMERS);
     });
     return content;
   }

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
@@ -208,6 +208,7 @@ const ViestiPageComponent = ({
 
   const currentViesti = viestiState.editedData!;
   const [editorHasChanges, setEditorHasChanges] = useState(false);
+  const [editorEmpty, setEditorEmpty] = useState(!viesti.viesti);
 
   useUnsavedChanges(
     viestiState.hasChanges || editorHasChanges,
@@ -218,25 +219,37 @@ const ViestiPageComponent = ({
     importHtml(editorRef.current, currentViesti.viesti || '');
   }, [editorRef, currentViesti.viesti]);
 
+  const normalizedEditorContent = useCallback(
+    (editor: LexicalEditor | null) => {
+      const editorContent = editor ? exportHtml(editor) : '';
+      return anyRealContentInHtml(editorContent) ? editorContent : '';
+    },
+    [],
+  );
+
+  const viestiToBeSaved = useCallback(() => {
+    if (editorHasChanges) {
+      return {
+        ...currentViesti,
+        viesti: normalizedEditorContent(editorRef.current),
+      };
+    }
+    return currentViesti;
+  }, [currentViesti, editorHasChanges, normalizedEditorContent]);
+
   const onSave = useCallback(() => {
-    updateViesti(
-      editorHasChanges
-        ? { ...currentViesti, viesti: exportHtml(editorRef.current) }
-        : currentViesti,
-    );
-  }, [currentViesti, editorHasChanges, updateViesti]);
+    updateViesti(viestiToBeSaved());
+  }, [viestiToBeSaved, updateViesti]);
 
   const updateEditorChanges = (editor: LexicalEditor) => {
-    const editorContent = exportHtml(editor);
-    const normalizedEditorContent = anyRealContentInHtml(editorContent)
-      ? editorContent
-      : '';
+    const normalizedContent = normalizedEditorContent(editor);
     const savedContent = currentViesti.viesti || '';
-    setEditorHasChanges(savedContent !== normalizedEditorContent);
+    setEditorHasChanges(savedContent !== normalizedContent);
+    setEditorEmpty(!normalizedContent);
   };
 
   const isViestiEmpty =
-    !currentViesti.tyyppi && !currentViesti.otsikko && !currentViesti.viesti;
+    !currentViesti.tyyppi && !currentViesti.otsikko && editorEmpty;
 
   const updateViestiPartially = (
     updatedViesti: Partial<Viesti>,
@@ -317,7 +330,7 @@ const ViestiPageComponent = ({
         <Stack direction="row" gap={theme.spacing(1)}>
           <OphButton
             data-testid={`viesti-kopioi-button`}
-            disabled={!currentViesti.viesti}
+            disabled={editorEmpty}
             variant="outlined"
             startIcon={<CopyAll />}
             onClick={() =>
@@ -338,14 +351,7 @@ const ViestiPageComponent = ({
                   `hakemus.viesti.vahvista.modal.vahvistaViesti`,
                 ),
                 handleConfirmAction: () => {
-                  vahvistaViesti(
-                    editorHasChanges
-                      ? {
-                          ...currentViesti,
-                          viesti: exportHtml(editorRef.current),
-                        }
-                      : currentViesti,
-                  );
+                  vahvistaViesti(viestiToBeSaved());
                   if (viestiState.hasChanges) {
                     // Vahvistettaessa viesti myös tallennetaan
                     // Vahvistamisen jälkeen editoriin tuodaan uusi tallentamaton viesti,


### PR DESCRIPTION
- Korjattu editorisisällön kopioinnissa tapahtuvaa markdown -exportia niin, että toimii paremmin yhteen atarun kanssa
- Korjattu painikkeiden tilankäsittelyä, ts. milloin painikkeet enabloituna / disabloituna
- Pieniä korjauksia editorin asetteluun