### PR TITLE
OPHTUTU-353: Lisätty myönteinen/kielteinen valinta UO päätöksiin

### DIFF
--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/kelpoisuus/KelpoisuusComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/kelpoisuus/KelpoisuusComponent.tsx
@@ -129,6 +129,27 @@ const KelpoisuusDirektiiviLiitannaisComponent = ({
   );
 };
 
+const KelpoisuusUOLiitannaisComponent = ({
+  t,
+  kelpoisuus,
+  updateAction,
+}: {
+  t: TFunction;
+  kelpoisuus: Kelpoisuus;
+  updateAction: KelpoisuusUpdateCallback;
+}) => {
+  return (
+    <MyonteinenTaiKielteinenPaatosComponent
+      myonteinenPaatos={kelpoisuus.myonteinenPaatos}
+      kielteisenPaatoksenPerustelut={kelpoisuus.kielteisenPaatoksenPerustelut}
+      updatePaatosAction={(paatos) => {
+        updateAction({ ...kelpoisuus, ...paatos });
+      }}
+      t={t}
+    />
+  );
+};
+
 export const KelpoisuusComponent = ({
   t,
   index,
@@ -144,6 +165,7 @@ export const KelpoisuusComponent = ({
   const showDirektiivitasoFields =
     kelpoisuus.kelpoisuus &&
     (sovellettuLaki === 'ap' || sovellettuLaki === 'ap_seut');
+  const showUOFields = kelpoisuus.kelpoisuus && sovellettuLaki === 'uo';
   const topLevelOptions = useMemo(
     () => [
       ...getPaatosTietoDropdownOptions(asiointikieli, kelpoisuusOptions, 2),
@@ -260,6 +282,13 @@ export const KelpoisuusComponent = ({
             theme={theme}
             kelpoisuus={kelpoisuus}
             kelpoisuusKey={selectedKelpoisuusKey?.value?.['fi']}
+            updateAction={updateKelpoisuus}
+          />
+        )}
+        {showUOFields && (
+          <KelpoisuusUOLiitannaisComponent
+            t={t}
+            kelpoisuus={kelpoisuus}
             updateAction={updateKelpoisuus}
           />
         )}


### PR DESCRIPTION
Lisätty myönteinen / kielteinen radio-button UO-päätöksille.

Myönteisen ja kielteisen valinnan jatkokysymykset yhä määrittelyssä.

Myönteisen jatkokysymykset on toistaiseksi poistettu tästä yhteydestä, sillä komponenttin toteutus teki sen helpoksi. Kielteisen päätöksen jatkokysymykset roikkuvat vielä mukana, sillä ne oli kiinteämpi osa myönteinen / kielteinen komponenttia.