### PR TITLE
OPHTUTU-413: Korjaa muokattu/muokkaa kenttiä

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/TutkintoController.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/TutkintoController.scala
@@ -130,17 +130,17 @@ class TutkintoController(
       val uudetTutkinnot = tutkintoService.haeTutkinnot(HakemusOid(hakemusOid))
       (tallennetutTutkinnot, uudetTutkinnot)
     } match {
-      case Success((tallennetutTutkinnot, uudetTutkinnot)) =>
+      case Success((tallennetutTutkinnot, tutkinnot)) =>
         auditLog.logChanges(
           auditLog.getUser(request),
           Map("hakemusOid" -> hakemusOid),
           TallennaTutkinnot,
           AuditUtil.getChanges(
             Some(mapper.writeValueAsString(tallennetutTutkinnot)),
-            Some(mapper.writeValueAsString(uudetTutkinnot))
+            Some(mapper.writeValueAsString(tutkinnot))
           )
         )
-        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(uudetTutkinnot))
+        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(tutkinnot))
       case Failure(e) =>
         LOG.error("Tutkintojen tallentaminen epäonnistui", e)
         errorMessageMapper.mapPlainErrorMessage(

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/TutkintoController.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/TutkintoController.scala
@@ -126,19 +126,21 @@ class TutkintoController(
         HakemusModifyOperationResolver.resolveTutkintoModifyOperations(tallennetutTutkinnot, tutkinnot),
         UserOid(user.userOid)
       )
-      (tallennetutTutkinnot, tutkinnot)
+
+      val uudetTutkinnot = tutkintoService.haeTutkinnot(HakemusOid(hakemusOid))
+      (tallennetutTutkinnot, uudetTutkinnot)
     } match {
-      case Success((tallennetutTutkinnot, tutkinnot)) =>
+      case Success((tallennetutTutkinnot, uudetTutkinnot)) =>
         auditLog.logChanges(
           auditLog.getUser(request),
           Map("hakemusOid" -> hakemusOid),
           TallennaTutkinnot,
           AuditUtil.getChanges(
             Some(mapper.writeValueAsString(tallennetutTutkinnot)),
-            Some(mapper.writeValueAsString(tutkinnot))
+            Some(mapper.writeValueAsString(uudetTutkinnot))
           )
         )
-        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(tutkinnot))
+        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(uudetTutkinnot))
       case Failure(e) =>
         LOG.error("Tutkintojen tallentaminen epäonnistui", e)
         errorMessageMapper.mapPlainErrorMessage(

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Paatos.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Paatos.scala
@@ -16,6 +16,7 @@ case class Paatos(
   paatostekstiVahvistettu: Option[LocalDateTime] = None,
   luotu: Option[LocalDateTime] = None,
   luoja: Option[String] = None,
+  muokattu: Option[LocalDateTime] = None,
   muokkaaja: Option[String] = None
 )
 

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Viesti.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Viesti.scala
@@ -14,6 +14,7 @@ case class Viesti(
   vahvistaja: Option[String] = None,
   luotu: Option[LocalDateTime] = None,
   luoja: Option[String] = None,
+  muokattu: Option[LocalDateTime] = None,
   muokkaaja: Option[String] = None
 )
 

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
@@ -35,6 +35,7 @@ class PaatosRepository extends BaseResultHandlers {
       paatostekstiVahvistettu = r.nextTimestampOption().map(_.toLocalDateTime),
       luotu = Some(r.nextTimestamp().toLocalDateTime),
       luoja = Some(r.nextString()),
+      muokattu = r.nextTimestampOption().map(_.toLocalDateTime),
       muokkaaja = r.nextStringOption()
     )
   )
@@ -134,7 +135,7 @@ class PaatosRepository extends BaseResultHandlers {
         lahetyspaiva = ${paatos.lahetyspaiva.map(java.sql.Timestamp.valueOf).orNull},
         muokkaaja = $luojaTaiMuokkaaja
       RETURNING id, hakemus_id, ratkaisutyyppi, seut_arviointi_tehty,
-        peruutus_tai_raukeaminen_lisatiedot, hyvaksymispaiva, lahetyspaiva, null, luotu, luoja, muokkaaja
+        peruutus_tai_raukeaminen_lisatiedot, hyvaksymispaiva, lahetyspaiva, null, luotu, luoja, muokattu, muokkaaja
     """.as[Paatos].head
   }
 
@@ -160,7 +161,7 @@ class PaatosRepository extends BaseResultHandlers {
         sql"""
           SELECT p.id, p.hakemus_id, p.ratkaisutyyppi, p.seut_arviointi_tehty,
             p.peruutus_tai_raukeaminen_lisatiedot, p.hyvaksymispaiva, p.lahetyspaiva,
-            pt.vahvistettu, p.luotu, p.luoja, p.muokkaaja
+            pt.vahvistettu, p.luotu, p.luoja, p.muokattu, p.muokkaaja
           FROM paatos p
           LEFT JOIN paatosteksti pt ON p.hakemus_id = pt.hakemus_id
           WHERE p.hakemus_id = ${hakemusId.toString}::uuid

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/ViestiRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/ViestiRepository.scala
@@ -30,6 +30,7 @@ class ViestiRepository extends BaseResultHandlers {
         vahvistaja = Option(r.nextString()),
         luotu = Some(r.nextTimestamp().toLocalDateTime),
         luoja = Some(r.nextString()),
+        muokattu = r.nextTimestampOption().map(_.toLocalDateTime),
         muokkaaja = r.nextStringOption()
       )
     )
@@ -48,7 +49,7 @@ class ViestiRepository extends BaseResultHandlers {
     try {
       db.run(
         sql"""
-          SELECT id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, muokkaaja
+          SELECT id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, muokattu, muokkaaja
           FROM viesti
           WHERE id = ${id.toString}::uuid
            """.as[Viesti].headOption,
@@ -68,7 +69,7 @@ class ViestiRepository extends BaseResultHandlers {
     try {
       db.run(
         sql"""
-          SELECT id, hakemus_id, kieli, tyyppi, otsikko, viesti, null, null, luotu, luoja, muokkaaja
+          SELECT id, hakemus_id, kieli, tyyppi, otsikko, viesti, null, null, luotu, luoja, muokattu, muokkaaja
           FROM viesti
           WHERE hakemus_id = ${hakemusId.toString}::uuid
             AND vahvistettu IS NULL
@@ -129,7 +130,7 @@ class ViestiRepository extends BaseResultHandlers {
             ${viesti.vahvistettu.map(java.sql.Timestamp.valueOf).orNull},
             ${viesti.vahvistaja.orNull},
             $luoja)
-            RETURNING id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, null
+            RETURNING id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, muokattu, muokkaaja
           """.as[Viesti].head,
         "lisaa_viesti"
       )
@@ -157,7 +158,7 @@ class ViestiRepository extends BaseResultHandlers {
               vahvistaja = ${viesti.vahvistaja.orNull},
               muokkaaja = $muokkaaja
           WHERE id = ${id.toString}::uuid
-          RETURNING id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, muokkaaja
+          RETURNING id, hakemus_id, kieli, tyyppi, otsikko, viesti, vahvistettu, vahvistaja, luotu, luoja, muokattu, muokkaaja
         """.as[Viesti].head,
         "tallenna_viesti"
       )

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
@@ -10,7 +10,6 @@ import fi.oph.tutu.backend.utils.{AuditLog, AuditOperation, TutuJsonFormats}
 import org.json4s.jvalue2extractable
 import org.json4s.native.JsonMethods
 import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.assertLinesMatch
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
@@ -599,6 +598,8 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
       .andExpect(jsonPath("$.id").isString)
       .andExpect(jsonPath("$.paatosTiedot[0].id").isString)
       .andExpect(jsonPath("$.paatosTiedot[0].lisaaTutkintoPaatostekstiin").isEmpty)
+      .andExpect(jsonPath("$.luoja").isString)
+      .andExpect(jsonPath("$.luotu").isString)
       .andExpect(content().json(paatosJSON))
     verify(auditLog, times(1)).logRead(any(), any(), eqTo(AuditOperation.ReadPaatos), any())
   }
@@ -634,6 +635,8 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
           "$.paatosTiedot[0].rinnastettavatTutkinnotTaiOpinnot[0].myonteisenPaatoksenLisavaatimukset.taydentavatOpinnot"
         ).value(true)
       )
+      .andExpect(jsonPath("$.luoja").isString)
+      .andExpect(jsonPath("$.luotu").isString)
     verify(auditLog, times(1)).logChanges(any(), any(), eqTo(AuditOperation.UpdatePaatos), any())
   }
 
@@ -656,7 +659,8 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
           "$.paatosTiedot[0].rinnastettavatTutkinnotTaiOpinnot[0].myonteisenPaatoksenLisavaatimukset.taydentavatOpinnot"
         ).value(true)
       )
-
+      .andExpect(jsonPath("$.luoja").isString)
+      .andExpect(jsonPath("$.luotu").isString)
     verify(auditLog, times(1)).logRead(any(), any(), eqTo(AuditOperation.ReadPaatos), any())
   }
 
@@ -669,6 +673,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
         paatosWithPaatosTiedotJaKelpoisuudet,
         "luoja",
         "luotu",
+        "muokattu",
         "muokkaaja",
         "paatosTietoOptions"
       )
@@ -691,6 +696,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
             "luoja",
             "luotu",
             "muokkaaja",
+            "muokattu",
             "paatosTietoOptions"
           )
         )
@@ -719,6 +725,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
             "luoja",
             "luotu",
             "muokkaaja",
+            "muokattu",
             "paatosTietoOptions"
           )
         )
@@ -736,6 +743,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
         paatosWithNewPaatosTiedotWithTutkinnotJaKelpoisuudet,
         "luoja",
         "luotu",
+        "muokattu",
         "muokkaaja",
         "paatosTietoOptions"
       )
@@ -760,6 +768,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
             "luoja",
             "luotu",
             "muokkaaja",
+            "muokattu",
             "paatosTietoOptions"
           )
         )

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/TutkintoControllerTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/TutkintoControllerTest.scala
@@ -17,7 +17,7 @@ import fi.oph.tutu.backend.utils.{AuditLog, AuditOperation}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import org.junit.jupiter.api.TestInstance.Lifecycle
-import org.junit.jupiter.api.{BeforeAll, Order, Test, TestInstance, TestMethodOrder}
+import org.junit.jupiter.api.{BeforeAll, BeforeEach, Order, Test, TestInstance, TestMethodOrder}
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,6 +33,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.test.web.servlet.setup.{DefaultMockMvcBuilder, MockMvcBuilders, MockMvcConfigurer}
 import org.springframework.web.context.WebApplicationContext
+import org.hamcrest.Matchers.{equalTo, everyItem, notNullValue}
+import com.fasterxml.jackson.databind.node.ObjectNode
 
 @AutoConfigureMockMvc
 @TestInstance(Lifecycle.PER_CLASS)
@@ -108,6 +110,12 @@ class TutkintoControllerTest extends IntegrationTestBase {
       )
   }
 
+  @BeforeEach
+  def setupMocks(): Unit = {
+    when(mockOnrService.haeNimiOption(any()))
+      .thenAnswer(i => i.getArgument(0, classOf[Option[String]]).map(_ => "Muokkaaja"))
+  }
+
   @Test
   @Order(1)
   @WithMockUser(value = esittelijaOidString, authorities = Array(SecurityConstants.SECURITY_ROOLI_CRUD_FULL))
@@ -128,9 +136,15 @@ class TutkintoControllerTest extends IntegrationTestBase {
       .andExpect(status().isOk)
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
       .andExpect(
-        content().json(
-          mapper.writeValueAsString(tutkinnot)
-        )
+        content().json {
+          val tree = mapper.readTree(mapper.writeValueAsString(tutkinnot))
+          tree.forEach { node =>
+            val obj = node.asInstanceOf[ObjectNode]
+            obj.remove("muokattu")
+            obj.remove("muokkaaja")
+          }
+          mapper.writeValueAsString(tree)
+        }
       )
     verify(auditLog, times(1)).logRead(any(), any(), eqTo(AuditOperation.ReadTutkinnot), any())
   }
@@ -158,7 +172,19 @@ class TutkintoControllerTest extends IntegrationTestBase {
       )
       .andExpect(status().isOk)
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(content().json(mapper.writeValueAsString(muutetutTutkinnot)))
+      .andExpect(jsonPath("$[*].muokkaaja", everyItem(equalTo("Muokkaaja"))))
+      .andExpect(jsonPath("$[*].muokattu", everyItem(notNullValue())))
+      .andExpect(
+        content().json {
+          val tree = mapper.readTree(mapper.writeValueAsString(muutetutTutkinnot))
+          tree.forEach { node =>
+            val obj = node.asInstanceOf[ObjectNode]
+            obj.remove("muokattu")
+            obj.remove("muokkaaja")
+          }
+          mapper.writeValueAsString(tree)
+        }
+      )
 
     val tutkinnot2 = tutkintoRepository.haeTutkinnotHakemusOidilla(hakemusOid)
 

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/ViestiControllerTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/ViestiControllerTest.scala
@@ -1,17 +1,7 @@
 package fi.oph.tutu.backend.controller
 
 import fi.oph.tutu.backend.IntegrationTestBase
-import fi.oph.tutu.backend.domain.{
-  Asiakirja,
-  DbEsittelija,
-  HakemusOid,
-  KansalaisuusKoodi,
-  Kieli,
-  OnrUser,
-  User,
-  UserOid,
-  Viesti
-}
+import fi.oph.tutu.backend.domain.{Asiakirja, HakemusOid, KansalaisuusKoodi, Kieli, OnrUser, User, Viesti}
 import fi.oph.tutu.backend.security.SecurityConstants
 import fi.oph.tutu.backend.service.{OnrService, UserService}
 import fi.oph.tutu.backend.utils.{AuditLog, AuditOperation}

--- a/tutu-frontend/playwright/fixtures/paatos1/index.ts
+++ b/tutu-frontend/playwright/fixtures/paatos1/index.ts
@@ -12,6 +12,8 @@ export const getPaatos = (): Paatos => {
     hyvaksymispaiva: null,
     lahetyspaiva: null,
     paatostekstiVahvistettu: null,
+    muokattu: '2024-06-01T12:00:00Z',
+    muokkaaja: 'Tutu',
   };
 };
 
@@ -35,5 +37,7 @@ export const getPaatosWithPaatosTiedot = (): Paatos => {
     hyvaksymispaiva: null,
     lahetyspaiva: null,
     paatostekstiVahvistettu: null,
+    muokattu: '2024-06-01T12:00:00Z',
+    muokkaaja: 'Tutu',
   };
 };

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
@@ -108,8 +108,8 @@ export default function PaatosEditorPage() {
         onSave={onSave}
         isSaving={updateOngoing}
         hasChanges={hasChanges}
-        lastSaved={paatosteksti.muokattu ?? paatosteksti.luotu}
-        modifier={paatosteksti.muokkaaja ?? paatosteksti.luoja}
+        lastSaved={paatosteksti.muokattu}
+        modifier={paatosteksti.muokkaaja}
       />
     </>
   );

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
@@ -33,7 +33,6 @@ import {
   TFunction,
   useTranslations,
 } from '@/src/lib/localization/hooks/useTranslations';
-import { Hakemus } from '@/src/lib/types/hakemus';
 import {
   VahvistettuViestiListItem,
   Viesti,
@@ -152,7 +151,6 @@ export default function ViestiPage() {
     <ViestiPageComponent
       t={t}
       viesti={viesti}
-      hakemus={hakemus}
       updateOngoing={updateOngoing}
       updateViesti={updateViesti}
       vahvistaViesti={vahvistaViestiJaPaivitaLista}
@@ -180,7 +178,6 @@ const handleCopy = (
 const ViestiPageComponent = ({
   t,
   viesti,
-  hakemus,
   updateOngoing,
   updateViesti,
   vahvistaViesti,
@@ -190,7 +187,6 @@ const ViestiPageComponent = ({
 }: {
   t: TFunction;
   viesti: Viesti;
-  hakemus: Hakemus;
   updateOngoing: boolean;
   updateViesti: ViestiUpdateCallback;
   vahvistaViesti: ViestiUpdateCallback;
@@ -388,8 +384,8 @@ const ViestiPageComponent = ({
         onSave={onSave}
         isSaving={updateOngoing}
         hasChanges={viestiState.hasChanges || editorHasChanges}
-        lastSaved={hakemus.muokattu}
-        modifier={hakemus.muokkaaja}
+        lastSaved={currentViesti.muokattu}
+        modifier={currentViesti.muokkaaja}
       />
     </Stack>
   );

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/page.tsx
@@ -48,7 +48,6 @@ export default function PaatostiedotPage() {
     isLoading: isHakemusLoading,
     hakemusState,
     error: hakemusError,
-    isSaving,
   } = useHakemus();
 
   const { tutkintoState } = useTutkinnot(hakemusState.editedData?.hakemusOid);
@@ -106,7 +105,7 @@ export default function PaatostiedotPage() {
   return (
     <Paatostiedot
       paatosState={paatosState}
-      updateOngoing={isSaving || isPaatosUpdateOngoing}
+      updateOngoing={isPaatosUpdateOngoing}
       hakemusState={hakemusState}
       tutkinnot={tutkintoState.editedData ?? []}
       paatosteksti={paatosteksti}
@@ -138,14 +137,7 @@ const Paatostiedot = ({
   const { showPaatosTekstiPreview, setShowPaatosTekstiPreview } =
     useShowPreview();
 
-  useUnsavedChanges(paatosState.hasChanges || hakemusState.hasChanges, () => {
-    if (hakemusState.hasChanges) {
-      hakemusState.discard();
-    }
-    if (paatosState.hasChanges) {
-      paatosState.discard();
-    }
-  });
+  useUnsavedChanges(paatosState.hasChanges, paatosState.discard);
 
   const [currentPaatosTiedot, setCurrentPaatosTiedot] = React.useState<
     PaatosTieto[]
@@ -324,12 +316,11 @@ const Paatostiedot = ({
           <SaveRibbon
             onSave={() => {
               paatosState.save();
-              hakemusState.save();
             }}
             isSaving={updateOngoing}
-            hasChanges={paatosState.hasChanges || hakemusState.hasChanges}
-            lastSaved={hakemus.muokattu}
-            modifier={hakemus.muokkaaja}
+            hasChanges={paatosState.hasChanges}
+            lastSaved={paatos.muokattu}
+            modifier={paatos.muokkaaja}
           />
         </Stack>
         {showPaatosTekstiPreview && (

--- a/tutu-frontend/src/app/hakemus/[oid]/perustelu/ap/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/perustelu/ap/page.tsx
@@ -359,8 +359,8 @@ export default function ApPage() {
         onSave={handleSave}
         isSaving={isPerusteluSaving}
         hasChanges={hasPerusteluChanges}
-        lastSaved={hakemus?.muokattu}
-        modifier={hakemus?.muokkaaja}
+        lastSaved={editedPerustelu?.muokattu}
+        modifier={editedPerustelu?.muokkaaja}
       />
     </>
   );

--- a/tutu-frontend/src/app/hakemus/[oid]/perustelu/uoro/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/perustelu/uoro/page.tsx
@@ -203,8 +203,8 @@ export default function UoroPage() {
         onSave={handleSave}
         isSaving={isPerusteluSaving}
         hasChanges={hasPerusteluChanges}
-        lastSaved={hakemus?.muokattu}
-        modifier={hakemus?.muokkaaja}
+        lastSaved={perusteluState.editedData?.muokattu}
+        modifier={perusteluState.editedData?.muokkaaja}
       />
     </>
   );

--- a/tutu-frontend/src/app/hakemus/[oid]/perustelu/yleiset/lausunto/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/perustelu/yleiset/lausunto/page.tsx
@@ -161,8 +161,8 @@ export default function Lausuntotiedot() {
           onSave={save}
           isSaving={isPerusteluSaving}
           hasChanges={hasPerusteluChanges}
-          lastSaved={hakemus?.muokattu}
-          modifier={hakemus?.muokkaaja}
+          lastSaved={editedPerustelu?.muokattu}
+          modifier={editedPerustelu?.muokkaaja}
         />
       </Stack>
     </PerusteluLayout>

--- a/tutu-frontend/src/app/hakemus/[oid]/perustelu/yleiset/perustelut/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/perustelu/yleiset/perustelut/page.tsx
@@ -21,6 +21,7 @@ import { usePerustelu } from '@/src/hooks/usePerustelu';
 import { useToaster } from '@/src/hooks/useToaster';
 import { useTutkinnot } from '@/src/hooks/useTutkinnot';
 import { useUnsavedChanges } from '@/src/hooks/useUnsavedChanges';
+import { lastModifiedInArray } from '@/src/lib/dateUtils';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { Hakemus } from '@/src/lib/types/hakemus';
 import { Perustelu } from '@/src/lib/types/perustelu';
@@ -102,6 +103,11 @@ const YleisetPerustelut = ({
     handleFetchError(addToast, tutkintoUpdateError, 'virhe.tallennus', t);
   }, [tutkintoUpdateError, addToast, t]);
 
+  const lastModified = lastModifiedInArray([
+    ...(perusteluState.editedData ? [perusteluState.editedData] : []),
+    ...(tutkintoState.editedData ?? []),
+  ]);
+
   return (
     <>
       <VirallinenTutkinnonMyontaja
@@ -151,8 +157,8 @@ const YleisetPerustelut = ({
         onSave={handleSave}
         isSaving={isSaving || isTutkintoSaving}
         hasChanges={hasChanges}
-        lastSaved={perusteluState.editedData?.muokattu} // Tutkintojakin voi muokata
-        modifier={perusteluState.editedData?.muokkaaja}
+        lastSaved={lastModified.muokattu}
+        modifier={lastModified.muokkaaja}
       />
     </>
   );

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/page.tsx
@@ -19,6 +19,7 @@ import { useKoodistoOptions } from '@/src/hooks/useKoodistoOptions';
 import useToaster from '@/src/hooks/useToaster';
 import { useTutkinnot } from '@/src/hooks/useTutkinnot';
 import { useUnsavedChanges } from '@/src/hooks/useUnsavedChanges';
+import { lastModifiedInArray } from '@/src/lib/dateUtils';
 import { findSisaltoQuestionAndAnswer } from '@/src/lib/hakemuspalveluUtils';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { Tutkinto } from '@/src/lib/types/tutkinto';
@@ -138,6 +139,8 @@ export default function TutkintoPage() {
     (tutkinto) => tutkinto.jarjestys === 'MUU',
   );
 
+  const lastModified = lastModifiedInArray(editedTutkinnot);
+
   return (
     <>
       <Stack
@@ -198,8 +201,8 @@ export default function TutkintoPage() {
         }}
         isSaving={isHakemusSaving || isSaving}
         hasChanges={hakemusState.hasChanges || tutkintoState.hasChanges}
-        lastSaved={hakemusState.editedData.muokattu}
-        modifier={hakemusState.editedData.muokkaaja}
+        lastSaved={lastModified.muokattu}
+        modifier={lastModified.muokkaaja}
       />
     </>
   );

--- a/tutu-frontend/src/components/SaveRibbon.tsx
+++ b/tutu-frontend/src/components/SaveRibbon.tsx
@@ -18,8 +18,8 @@ interface SaveRibbonProps {
   onSave: () => void;
   isSaving: boolean;
   hasChanges: boolean;
-  lastSaved?: string;
-  modifier?: string;
+  lastSaved?: string | null;
+  modifier?: string | null;
 }
 
 export const SaveRibbon = ({

--- a/tutu-frontend/src/lib/dateUtils.ts
+++ b/tutu-frontend/src/lib/dateUtils.ts
@@ -5,3 +5,26 @@ export const formatHelsinki = (
   value: string | Date | number,
   fmt: string,
 ): string => formatInTimeZone(new Date(value), 'Europe/Helsinki', fmt);
+
+type Muokkaus = { muokattu?: string | null; muokkaaja?: string | null };
+
+export function lastModifiedInArray(entries: Muokkaus[]): Muokkaus {
+  let latest: Muokkaus = { muokattu: undefined, muokkaaja: undefined };
+
+  if (!entries || entries.length === 0) {
+    return latest;
+  }
+
+  let latestMs = 0;
+
+  for (const e of entries) {
+    if (!e.muokattu) continue;
+    const t = new Date(e.muokattu).getTime();
+    if (t && t > latestMs) {
+      latest = e;
+      latestMs = t;
+    }
+  }
+
+  return latest;
+}

--- a/tutu-frontend/src/lib/types/paatos.ts
+++ b/tutu-frontend/src/lib/types/paatos.ts
@@ -61,6 +61,10 @@ export type Paatos = {
   hyvaksymispaiva: string | null;
   lahetyspaiva: string | null;
   paatostekstiVahvistettu: string | null;
+  luotu: string | null;
+  luoja: string | null;
+  muokattu: string | null;
+  muokkaaja: string | null;
 };
 
 export type TutkintoTaiOpinto = {

--- a/tutu-frontend/src/lib/types/tutkinto.ts
+++ b/tutu-frontend/src/lib/types/tutkinto.ts
@@ -17,4 +17,6 @@ export type Tutkinto = {
   opinnaytetyo?: boolean | null;
   harjoittelu?: boolean | null;
   perustelunLisatietoja?: string;
+  muokattu?: string | null;
+  muokkaaja?: string | null;
 };

--- a/tutu-frontend/src/lib/types/viesti.ts
+++ b/tutu-frontend/src/lib/types/viesti.ts
@@ -10,6 +10,8 @@ export type Viesti = {
   viesti?: string | null;
   vahvistettu?: string;
   vahvistaja?: string;
+  muokattu?: string | null;
+  muokkaaja?: string | null;
 };
 
 export type VahvistettuViestiListItem = {

--- a/tutu-frontend/src/lib/types/viesti.ts
+++ b/tutu-frontend/src/lib/types/viesti.ts
@@ -10,6 +10,8 @@ export type Viesti = {
   viesti?: string | null;
   vahvistettu?: string;
   vahvistaja?: string;
+  luotu?: string | null;
+  luoja?: string | null;
   muokattu?: string | null;
   muokkaaja?: string | null;
 };


### PR DESCRIPTION
Päätöstieto muokattu/muokkaja korjattu (OID muokkaaja saveribbonissa koska oli "luotu" kenttään defaultattu).
Tutkintoihin lisätty myös ja otetaan uusin muokkaaja (vaikka kaikki päivittyvät),
mutta on mahdollista lisätä myöhemmin hakemuksen muokkausaika vertailuun (yksi yhteishaku kenttä päivittyy hakemukseen näkymässä).

Samoin viesti/perustelu muokkaajia viilattu. Viesti editorissa otsikon päivittäminen alkuun ei pakolla näytä vielä muokkaajaa sen jälkeen, koska on vasta "luotu" ja ei käytetä luotu kenttiä ollenkaan sillä "muokattu viimeksi".