### PR TITLE
OPHTUTU-410: Vie paatostekstit tolgeeseen

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Kielistetty.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Kielistetty.scala
@@ -8,6 +8,9 @@ object Kieli:
     case "fi"                             => Some(fi)
     case "sv"                             => Some(sv)
     case "en"                             => Some(en)
+    case "finnish"                        => Some(fi) // Ataru käyttää kielinä pitkiä muotoja
+    case "swedish"                        => Some(sv)
+    case "english"                        => Some(en)
     case s if Option(s).forall(_.isBlank) => None
     case _                                => throw new IllegalArgumentException(s"Tuntematon kieli: $value")
   }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PaatosService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PaatosService.scala
@@ -2,7 +2,7 @@ package fi.oph.tutu.backend.service
 
 import fi.oph.tutu.backend.domain.*
 import fi.oph.tutu.backend.repository.{HakemusRepository, PaatosRepository}
-import fi.oph.tutu.backend.service.generator.paatosteksti
+import fi.oph.tutu.backend.service.generator.paatosteksti.PaatosTekstiGenerator
 import fi.oph.tutu.backend.utils.{Constants, TutuJsonFormats}
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jvalue2extractable
@@ -22,7 +22,8 @@ class PaatosService(
   hallintoOikeusService: HallintoOikeusService,
   ataruLomakeParser: AtaruLomakeParser,
   maakoodiService: MaakoodiService,
-  onrService: OnrService
+  onrService: OnrService,
+  paatosTekstiGenerator: PaatosTekstiGenerator
 ) extends TutuJsonFormats {
   val LOG: Logger = LoggerFactory.getLogger(classOf[PaatosService])
 
@@ -157,15 +158,25 @@ class PaatosService(
     val tutkinnot: Seq[Tutkinto]           = tutkintoService.haeTutkinnot(hakemusOid)
     val ataruHakemus: Option[AtaruHakemus] = hakemuspalveluService.haeJaParsiHakemus(hakemusOid).toOption
     val paatos: Paatos                     = haePaatos(hakemusOid).get
-    val paatosKieli: String                = {
-      findAnswerByAtaruKysymysId(Constants.ATARU_PAATOS_KIELI, ataruHakemus.get.content.answers).getOrElse("fi")
+    val paatosKieli: Kieli                 = {
+      findAnswerByAtaruKysymysId(Constants.ATARU_PAATOS_KIELI, ataruHakemus.get.content.answers)
+        .flatMap(Kieli.optionFromString(_))
+        .getOrElse(Kieli.fi)
     }
     val hakijanKunta = findSingleStringAnswer("home-town", ataruHakemus.get.content.answers) match {
       case Some(kunta) => kunta
       case None        => "009"
     }
     val hallintoOikeus: HallintoOikeus = hallintoOikeusService.haeHallintoOikeusByKunta(hakijanKunta)
-    paatosteksti.generatePaatosTeksti(hakemus, tutkinnot, paatos, paatosKieli, hallintoOikeus, maakoodiService)
+
+    this.paatosTekstiGenerator.generatePaatosTeksti(
+      hakemus,
+      tutkinnot,
+      paatos,
+      paatosKieli,
+      hallintoOikeus,
+      maakoodiService
+    )
   }
 
   def haePaatosteksti(

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationMaintenance.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationMaintenance.scala
@@ -1,0 +1,22 @@
+package fi.oph.tutu.backend.service
+
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Profile(Array("!test"))
+@Component
+class TranslationMaintenance(
+  translationService: TranslationService,
+  hakemuspalveluService: HakemuspalveluService,
+  onrService: OnrService
+) {
+  val LOG: Logger = LoggerFactory.getLogger(classOf[TranslationMaintenance])
+
+  @Scheduled(fixedRateString = "${caching.spring.hourTTL}")
+  def hourlyRefresh(): Unit = {
+    LOG.info("Päivitetään käännösvälimuisti")
+    translationService.loadAllIntoCache()
+  }
+}

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationService.scala
@@ -10,6 +10,7 @@ import org.springframework.stereotype.{Component, Service}
 
 import fi.oph.tutu.backend.utils.TutuJsonFormats
 import fi.oph.tutu.backend.TutuBackendApplication.CALLER_ID
+import fi.oph.tutu.backend.domain.Kieli
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class TranslationEntry(
@@ -47,22 +48,23 @@ class TranslationService(httpService: HttpService, mapper: ObjectMapper) {
       .build()
   )
 
-  def getTranslation(locale: String, key: String): String = {
+  def getTranslation(locale: Kieli, key: String): String = {
     httpService.get(
       translationCasClient,
       s"$opintopolku_virkailija_domain/lokalisointi/api/v1/localisation?category=tutu-kasittely&key=$key&locale=$locale"
     ) match {
       case Left(error: Throwable) =>
+        System.out.println(s"Error fetching translation for key '$key' and locale '$locale': ${error.getMessage}")
         error match {
           case _ => key
         }
       case Right(jsonString: String) => {
         val items            = mapper.readValue(jsonString, new TypeReference[Seq[TranslationEntry]] {})
         val maybeTranslation = items
-          .filter(_.locale == locale)
+          .filter(_.locale == locale.toString())
           .map(_.value)
           .headOption
-
+        System.out.println(s"Fetched translation for key '$key' and locale '$locale': ${jsonString}")
         maybeTranslation match {
           case None              => key
           case Some(translation) => translation

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/TranslationService.scala
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.vm.sade.javautils.nio.cas.{CasClient, CasClientBuilder, CasConfig}
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.annotation.{Autowired, Value}
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.Cacheable
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.stereotype.{Component, Service}
 
-import fi.oph.tutu.backend.utils.TutuJsonFormats
 import fi.oph.tutu.backend.TutuBackendApplication.CALLER_ID
 import fi.oph.tutu.backend.domain.Kieli
+import org.springframework.cache.Cache
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class TranslationEntry(
@@ -24,6 +26,8 @@ case class TranslationEntry(
 @Component
 @Service
 class TranslationService(httpService: HttpService, mapper: ObjectMapper) {
+  val LOG: Logger = LoggerFactory.getLogger(classOf[TranslationService])
+
   @Value("${opintopolku.virkailija.url}")
   val opintopolku_virkailija_domain: String = null
 
@@ -32,6 +36,9 @@ class TranslationService(httpService: HttpService, mapper: ObjectMapper) {
 
   @Value("${tutu.backend.cas.password}")
   val cas_password: String = null
+
+  @Autowired
+  val cacheManager: CacheManager = null
 
   private lazy val translationCasClient: CasClient = CasClientBuilder.build(
     CasConfig
@@ -48,28 +55,60 @@ class TranslationService(httpService: HttpService, mapper: ObjectMapper) {
       .build()
   )
 
+  private def getTranslationCache(): Cache = {
+    Option(cacheManager.getCache("translations"))
+      .getOrElse(throw new RuntimeException("Translation cachea ei löydy"))
+  }
+
+  private def getCachedTranslation(locale: Kieli, key: String): Option[String] = {
+    val cacheKey = s"$locale:$key"
+    Option(getTranslationCache().get(cacheKey))
+      .flatMap(v => Option(v.get().asInstanceOf[String]))
+  }
+
+  def loadAllIntoCache(): Unit = {
+    httpService.get(
+      translationCasClient,
+      s"$opintopolku_virkailija_domain/lokalisointi/api/v1/localisation?category=tutu-kasittely"
+    ) match {
+      case Left(error: Throwable) =>
+        LOG.warn(s"Käännösten lataus epäonnistui: ${error.getMessage}")
+      case Right(jsonString: String) =>
+        val items = mapper.readValue(jsonString, new TypeReference[Seq[TranslationEntry]] {})
+        val cache = getTranslationCache()
+        items.foreach(e => {
+          cache.put(s"${e.locale}:${e.key}", e.value)
+        })
+        LOG.info(s"Ladattu ${items.size} käännöstä")
+    }
+  }
+
+  /*
+   * Simple {var} replacement for parameters in translations.
+   */
+  def getTranslation(locale: Kieli, key: String, params: Map[String, String]): String = {
+    val template = getCachedTranslation(locale, key)
+      .getOrElse(getTranslation(locale, key))
+
+    params.foldLeft(template) { case (text, (k, v)) => text.replace(s"{$k}", v) }
+  }
+
+  @Cacheable(value = Array("translations"), key = "#locale + ':' + #key", unless = "#result == #key")
   def getTranslation(locale: Kieli, key: String): String = {
     httpService.get(
       translationCasClient,
       s"$opintopolku_virkailija_domain/lokalisointi/api/v1/localisation?category=tutu-kasittely&key=$key&locale=$locale"
     ) match {
       case Left(error: Throwable) =>
-        System.out.println(s"Error fetching translation for key '$key' and locale '$locale': ${error.getMessage}")
-        error match {
-          case _ => key
-        }
-      case Right(jsonString: String) => {
-        val items            = mapper.readValue(jsonString, new TypeReference[Seq[TranslationEntry]] {})
-        val maybeTranslation = items
+        LOG.warn(s"Käännöksen haku epäonnistui key:lle $key ($locale): ${error.getMessage}")
+        key
+      case Right(jsonString: String) =>
+        val items = mapper.readValue(jsonString, new TypeReference[Seq[TranslationEntry]] {})
+        items
           .filter(_.locale == locale.toString())
           .map(_.value)
           .headOption
-        System.out.println(s"Fetched translation for key '$key' and locale '$locale': ${jsonString}")
-        maybeTranslation match {
-          case None              => key
-          case Some(translation) => translation
-        }
-      }
+          .getOrElse(key)
     }
   }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/ViestiService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/ViestiService.scala
@@ -105,9 +105,9 @@ class ViestiService(
         viesti.kieli match {
           case Some(kieli) =>
             val tervehdysTeksti =
-              translationService.getTranslation(kieli.toString, "hakemus.viesti.allekirjoitus.tervehdys")
+              translationService.getTranslation(kieli, "hakemus.viesti.allekirjoitus.tervehdys")
             val ophTeksti =
-              translationService.getTranslation(kieli.toString, "hakemus.viesti.allekirjoitus.opetushallitus")
+              translationService.getTranslation(kieli, "hakemus.viesti.allekirjoitus.opetushallitus")
             val sahkoposti    = esittelija.sahkoposti.getOrElse("")
             val allekirjoitus =
               s"""<p>

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
@@ -117,13 +117,11 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
   ): String = {
     val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
     val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
-    lang match {
-      case Kieli.fi =>
-        s"""<p>Hakijan suorittama korkeakoulututkinto$tutkinto rinnastetaan Suomessa suoritettavaan ${koulu}n korkeakoulututkintoon.</p>"""
-      case _ =>
-        s"""<p>Den högskoleexamen som sökanden har avlagt$tutkinto jämställs med $koulu högskoleexamen som avläggs i Finland.</p>"""
-    }
-
+    translationService.getTranslation(
+      lang,
+      "paatosteksti.tasoPaatosTutkinto",
+      Map("tutkintoNimi" -> tutkinto, "koulu" -> koulu)
+    )
   }
 
   private def getTasoPaatosPerusteluBodyText(
@@ -133,12 +131,11 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
   ): String = {
     val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
     val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
-    lang match {
-      case Kieli.fi =>
-        s"""<p>Opetushallitus on arvioinut hakijan tutkinnon$tutkinto vastaavan tasoltaan Suomessa suoritettavaa $koulu korkeakoulututkintoa. Arvio perustuu siihen, että tutkintoon johtanut korkeakouluopintojen kokonaisuus vastaa laajuudeltaan, vaativuudeltaan ja suuntautumiseltaan ${koulu}n korkeakoulututkintoon johtavaa korkeakouluopintojen kokonaisuutta.</p>"""
-      case _ =>
-        s"""<p>Utbildningsstyrelsen har bedömt att sökandens examen$tutkinto till sin nivå motsvarar en $koulu högskoleexamen som avläggs i Finland. Bedömningen grundar sig på att den helhet av högskolestudier som har lett till examen med hänsyn till dess omfång, svårighetsgrad och inriktning motsvarar den helhet av högskolestudier som leder till $koulu högskoleexamen.</p>"""
-    }
+    translationService.getTranslation(
+      lang,
+      "paatosteksti.tasoPaatosPerusteluBody",
+      Map("tutkintoNimi" -> tutkinto, "koulu" -> koulu)
+    )
   }
 
   private def getTasoPaatosPerusteluHeader(lang: Kieli): String = lang match {
@@ -149,12 +146,6 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
   private def getTasoPaatosLakiText(lang: Kieli): String = {
     this.translationService.getTranslation(lang, "paatosteksti.tasoPaatosLaki")
   }
-  /*lang match {
-  case Kieli.fi =>
-    "<strong>Lainkohdat, joihin päätös perustuu</strong><p>Laki ulkomailla suoritettujen korkeakouluopintojen tuottamasta virkakelpoisuudesta (1385/2015), 2, 3 ja 6 §</p>"
-  case _ =>
-    "<strong>Tillämpade rättsnormer</strong><p>Lagen om den tjänstebehörighet som högskolestudier utomlands medför (1385/2015), 2, 3 och 6 §</p>"
-}*/
 
   private def parseHallintoOikeusName(hallintoOikeus: String): String = {
     if (hallintoOikeus.contains("hallintotuomioistuin")) {
@@ -164,28 +155,17 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     }
   }
 
-  private def getCommonPaatosValitusoikeusText(lang: Kieli, hallintoOikeus: String): String = lang match {
-    case Kieli.fi =>
-      s"""<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla ${parseHallintoOikeusName(
-          hallintoOikeus
-        )}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>"""
-    case _ =>
-      s"""<strong>Besvärsrätt</strong><p>Ändring i detta beslut får sökas genom besvär hos $hallintoOikeus. Besvärstiden och förfarandet framgår av bifogade besvärsanvisning.</p>"""
+  private def getCommonPaatosValitusoikeusText(lang: Kieli, hallintoOikeus: String): String = {
+    val hallintoOikeusNimi = if (lang == Kieli.fi) parseHallintoOikeusName(hallintoOikeus) else hallintoOikeus
+    translationService.getTranslation(lang, "paatosteksti.valitusoikeus", Map("hallintoOikeus" -> hallintoOikeusNimi))
   }
 
   private def getCommonMaksunOikaisuText(lang: Kieli, isPeruutus: Boolean = false): String = {
+    val paatosMaksu =
+      if (isPeruutus) ""
+      else translationService.getTranslation(lang, "paatosteksti.maksunOikaisu.paatosMaksu")
 
-    val paatosMaksu = (lang, isPeruutus) match {
-      case (_, true)         => ""
-      case (Kieli.fi, false) => "<p>Päätösmaksu 395 euroa</p>"
-      case _                 => "<p>Beslutsavgift 395 euro</p>"
-    }
-    lang match {
-      case Kieli.fi =>
-        s"""<strong>Maksun oikaisu</strong><p>Päätöksestä perityt maksut perustuvat opetus- ja kulttuuriministeriön asetukseen Opetushallituksen ja sen erillisyksiköiden suoritteiden maksullisuudesta (1508/2025, 1 ja 2 §). Maksuihin voi vaatia oikaisua Opetushallitukselta. Liitteenä olevasta oikaisuvaatimusosoituksesta ilmenee oikaisuvaatimuksen määräaika ja se, miten oikaisua vaadittaessa on meneteltävä.</p><p>Käsittelymaksu 100 euroa</p>$paatosMaksu"""
-      case _ =>
-        s"""<strong>Omprövning som berör avgifterna</strong><p>Avgifterna för beslutet baserar sig på undervisnings- och kulturministeriets förordning om Utbildningsstyrelsens och dess fristående enheters avgiftsbelagda prestationer (1508/2025, 1 och 2 §). Omprövning som berör avgifterna kan begäras av Utbildningsstyrelsen. Av bifogade anvisning för begäran om omprövning framgår tiden för begäran om omprövning och ansökningsförfarandet.</p><p>Behandlingsavgift 100 euro</p>$paatosMaksu"""
-    }
+    translationService.getTranslation(lang, "paatosteksti.maksunOikaisu", Map("paatosMaksu" -> paatosMaksu))
   }
 
   private def getSelectTutkintoTasoText(lang: Kieli): String = lang match {

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
@@ -3,6 +3,8 @@ package fi.oph.tutu.backend.service.generator.paatosteksti
 import fi.oph.tutu.backend.service.MaakoodiService
 import fi.oph.tutu.backend.domain.*
 import fi.oph.tutu.backend.service.generator.formatDate
+import fi.oph.tutu.backend.service.TranslationService
+import org.springframework.stereotype.{Component, Service}
 
 // See TutkintoComponent.tsx
 val tutkintoOtsikkoLabelMap: Map[String, String] = Map(
@@ -20,291 +22,296 @@ val tutkintoOtsikkoLabelMap: Map[String, String] = Map(
   "foregaendehogskolestudier"    -> "Föregående högskolestudier"
 )
 
-private def getCommonPaatosHeader(
-  hakemus: Hakemus,
-  tutkinnot: Seq[Tutkinto],
-  paatos: Paatos,
-  paatosKieli: String,
-  maakoodiService: MaakoodiService
-): String = {
-  val hakijaNimi        = s"${hakemus.hakija.sukunimi} ${hakemus.hakija.etunimet}"
-  val hakijaSyntymaaika = hakemus.hakija.syntymaaika
+@Component
+@Service
+class PaatosTekstiGenerator(translationService: TranslationService) {
 
-  val isPeruutus = paatos.ratkaisutyyppi match {
-    case Some(Ratkaisutyyppi.PeruutusTaiRaukeaminen) => true
-    case _                                           => false
-  }
+  private def getCommonPaatosHeader(
+    hakemus: Hakemus,
+    tutkinnot: Seq[Tutkinto],
+    paatos: Paatos,
+    paatosKieli: Kieli,
+    maakoodiService: MaakoodiService
+  ): String = {
+    val hakijaNimi        = s"${hakemus.hakija.sukunimi} ${hakemus.hakija.etunimet}"
+    val hakijaSyntymaaika = hakemus.hakija.syntymaaika
 
-  val tutkintoBlocks: String =
-    if (isPeruutus) ""
-    else {
-      tutkinnot
-        .map { tutkinto =>
-          val tutkintoOtsikko =
-            tutkinto.todistusOtsikko
-              .map(o => tutkintoOtsikkoLabelMap.getOrElse(o, o))
-              .getOrElse("")
-
-          val tutkintoNimi     = tutkinto.nimi.getOrElse("")
-          val tutkinnonPaaAine = tutkinto.paaAineTaiErikoisala.getOrElse("")
-          val korkeakoulu      = tutkinto.oppilaitos.getOrElse("")
-          val maakoodiUri      = tutkinto.maakoodiUri
-
-          val sijaintimaa = maakoodiUri
-            .flatMap(maakoodiUri =>
-              maakoodiService
-                .getMaakoodiByUri(maakoodiUri)
-                .flatMap(m => Some(if (paatosKieli == "finnish") m.fi else m.sv))
-            )
-            .getOrElse("")
-
-          val tutkintoParts =
-            Seq(tutkintoNimi, tutkinnonPaaAine, korkeakoulu, sijaintimaa)
-              .map(_.trim)
-              .filter(_.nonEmpty)
-              .mkString("<br>")
-
-          val todistuksenPaivamaara = tutkinto.todistuksenPaivamaara.getOrElse("")
-          val tutkintoOtsikkoLabel  = tutkintoOtsikkoLabelMap.getOrElse(
-            tutkintoOtsikko,
-            tutkintoOtsikko
-          )
-
-          if (tutkintoParts.nonEmpty) { // Filtteröi esim. Muut tutkinnot pois
-            if (paatosKieli == "finnish")
-              s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Todistuksen päivämäärä: $todistuksenPaivamaara</p>"""
-            else
-              s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Datum för bevis: $todistuksenPaivamaara</p>"""
-          } else {
-            ""
-          }
-        }
-        .mkString("")
+    val isPeruutus = paatos.ratkaisutyyppi match {
+      case Some(Ratkaisutyyppi.PeruutusTaiRaukeaminen) => true
+      case _                                           => false
     }
 
-  paatosKieli match {
-    case "finnish" =>
-      s"""<p>Hakija:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
-    case _ =>
-      s"""<p>Sökande:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
+    val tutkintoBlocks: String =
+      if (isPeruutus) ""
+      else {
+        tutkinnot
+          .map { tutkinto =>
+            val tutkintoOtsikko =
+              tutkinto.todistusOtsikko
+                .map(o => tutkintoOtsikkoLabelMap.getOrElse(o, o))
+                .getOrElse("")
+
+            val tutkintoNimi     = tutkinto.nimi.getOrElse("")
+            val tutkinnonPaaAine = tutkinto.paaAineTaiErikoisala.getOrElse("")
+            val korkeakoulu      = tutkinto.oppilaitos.getOrElse("")
+            val maakoodiUri      = tutkinto.maakoodiUri
+
+            val sijaintimaa = maakoodiUri
+              .flatMap(maakoodiUri =>
+                maakoodiService
+                  .getMaakoodiByUri(maakoodiUri)
+                  .flatMap(m => Some(if (paatosKieli == Kieli.fi) m.fi else m.sv))
+              )
+              .getOrElse("")
+
+            val tutkintoParts =
+              Seq(tutkintoNimi, tutkinnonPaaAine, korkeakoulu, sijaintimaa)
+                .map(_.trim)
+                .filter(_.nonEmpty)
+                .mkString("<br>")
+
+            val todistuksenPaivamaara = tutkinto.todistuksenPaivamaara.getOrElse("")
+            val tutkintoOtsikkoLabel  = tutkintoOtsikkoLabelMap.getOrElse(
+              tutkintoOtsikko,
+              tutkintoOtsikko
+            )
+
+            if (tutkintoParts.nonEmpty) { // Filtteröi esim. Muut tutkinnot pois
+              if (paatosKieli == Kieli.fi)
+                s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Todistuksen päivämäärä: $todistuksenPaivamaara</p>"""
+              else
+                s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Datum för bevis: $todistuksenPaivamaara</p>"""
+            } else {
+              ""
+            }
+          }
+          .mkString("")
+      }
+
+    paatosKieli match {
+      case Kieli.fi =>
+        s"""<p>Hakija:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
+      case _ =>
+        s"""<p>Sökande:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
+    }
   }
-}
 
-private def getTasoPaatosHeader(lang: String, count: Number): String = lang match {
-  case "finnish" => s"""<strong>${if (count == 1) s"Tutkinnon" else s"Tutkintojen"} rinnastaminen</strong>"""
-  case _         => s"""<strong>Jämställande av examen</strong>"""
-}
-
-private def getKorkeakouluTasoText(lang: String, tutkintoTaso: TutkintoTaso): String = {
-  (lang, tutkintoTaso) match {
-    case ("finnish", TutkintoTaso.YlempiKorkeakoulu) => "ylempää"
-    case (_, TutkintoTaso.YlempiKorkeakoulu)         => "högre"
-    case ("finnish", _)                              => "alempaa"
-    case _                                           => "lägre"
-  }
-}
-
-private def getTasoPaatosTutkintoText(
-  lang: String,
-  tutkintoTaso: TutkintoTaso,
-  tutkintoNimi: Option[String]
-): String = {
-  val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
-  val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
-  lang match {
-    case "finnish" =>
-      s"""<p>Hakijan suorittama korkeakoulututkinto$tutkinto rinnastetaan Suomessa suoritettavaan ${koulu}n korkeakoulututkintoon.</p>"""
-    case _ =>
-      s"""<p>Den högskoleexamen som sökanden har avlagt$tutkinto jämställs med $koulu högskoleexamen som avläggs i Finland.</p>"""
+  private def getTasoPaatosHeader(lang: Kieli, count: Number): String = lang match {
+    case Kieli.fi => s"""<strong>${if (count == 1) s"Tutkinnon" else s"Tutkintojen"} rinnastaminen</strong>"""
+    case _        => s"""<strong>Jämställande av examen</strong>"""
   }
 
-}
-
-private def getTasoPaatosPerusteluBodyText(
-  lang: String,
-  tutkintoTaso: TutkintoTaso,
-  tutkintoNimi: Option[String]
-): String = {
-  val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
-  val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
-  lang match {
-    case "finnish" =>
-      s"""<p>Opetushallitus on arvioinut hakijan tutkinnon$tutkinto vastaavan tasoltaan Suomessa suoritettavaa $koulu korkeakoulututkintoa. Arvio perustuu siihen, että tutkintoon johtanut korkeakouluopintojen kokonaisuus vastaa laajuudeltaan, vaativuudeltaan ja suuntautumiseltaan ${koulu}n korkeakoulututkintoon johtavaa korkeakouluopintojen kokonaisuutta.</p>"""
-    case _ =>
-      s"""<p>Utbildningsstyrelsen har bedömt att sökandens examen$tutkinto till sin nivå motsvarar en $koulu högskoleexamen som avläggs i Finland. Bedömningen grundar sig på att den helhet av högskolestudier som har lett till examen med hänsyn till dess omfång, svårighetsgrad och inriktning motsvarar den helhet av högskolestudier som leder till $koulu högskoleexamen.</p>"""
+  private def getKorkeakouluTasoText(lang: Kieli, tutkintoTaso: TutkintoTaso): String = {
+    (lang, tutkintoTaso) match {
+      case (Kieli.fi, TutkintoTaso.YlempiKorkeakoulu) => "ylempää"
+      case (_, TutkintoTaso.YlempiKorkeakoulu)        => "högre"
+      case (Kieli.fi, _)                              => "alempaa"
+      case _                                          => "lägre"
+    }
   }
-}
 
-private def getTasoPaatosPerusteluHeader(lang: String): String = lang match {
-  case "finnish" => "<strong>Perustelu</strong>"
-  case _         => "<strong>Motivering</strong>"
-}
+  private def getTasoPaatosTutkintoText(
+    lang: Kieli,
+    tutkintoTaso: TutkintoTaso,
+    tutkintoNimi: Option[String]
+  ): String = {
+    val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
+    val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
+    lang match {
+      case Kieli.fi =>
+        s"""<p>Hakijan suorittama korkeakoulututkinto$tutkinto rinnastetaan Suomessa suoritettavaan ${koulu}n korkeakoulututkintoon.</p>"""
+      case _ =>
+        s"""<p>Den högskoleexamen som sökanden har avlagt$tutkinto jämställs med $koulu högskoleexamen som avläggs i Finland.</p>"""
+    }
 
-private def getTasoPaatosLakiText(lang: String): String = lang match {
-  case "finnish" =>
+  }
+
+  private def getTasoPaatosPerusteluBodyText(
+    lang: Kieli,
+    tutkintoTaso: TutkintoTaso,
+    tutkintoNimi: Option[String]
+  ): String = {
+    val tutkinto = tutkintoNimi.map(n => s" ($n)").getOrElse("")
+    val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
+    lang match {
+      case Kieli.fi =>
+        s"""<p>Opetushallitus on arvioinut hakijan tutkinnon$tutkinto vastaavan tasoltaan Suomessa suoritettavaa $koulu korkeakoulututkintoa. Arvio perustuu siihen, että tutkintoon johtanut korkeakouluopintojen kokonaisuus vastaa laajuudeltaan, vaativuudeltaan ja suuntautumiseltaan ${koulu}n korkeakoulututkintoon johtavaa korkeakouluopintojen kokonaisuutta.</p>"""
+      case _ =>
+        s"""<p>Utbildningsstyrelsen har bedömt att sökandens examen$tutkinto till sin nivå motsvarar en $koulu högskoleexamen som avläggs i Finland. Bedömningen grundar sig på att den helhet av högskolestudier som har lett till examen med hänsyn till dess omfång, svårighetsgrad och inriktning motsvarar den helhet av högskolestudier som leder till $koulu högskoleexamen.</p>"""
+    }
+  }
+
+  private def getTasoPaatosPerusteluHeader(lang: Kieli): String = lang match {
+    case Kieli.fi => "<strong>Perustelu</strong>"
+    case _        => "<strong>Motivering</strong>"
+  }
+
+  private def getTasoPaatosLakiText(lang: Kieli): String = {
+    this.translationService.getTranslation(lang, "paatosteksti.tasoPaatosLaki")
+  }
+  /*lang match {
+  case Kieli.fi =>
     "<strong>Lainkohdat, joihin päätös perustuu</strong><p>Laki ulkomailla suoritettujen korkeakouluopintojen tuottamasta virkakelpoisuudesta (1385/2015), 2, 3 ja 6 §</p>"
   case _ =>
     "<strong>Tillämpade rättsnormer</strong><p>Lagen om den tjänstebehörighet som högskolestudier utomlands medför (1385/2015), 2, 3 och 6 §</p>"
-}
+}*/
 
-private def parseHallintoOikeusName(hallintoOikeus: String): String = {
-  if (hallintoOikeus.contains("hallintotuomioistuin")) {
-    hallintoOikeus.replace("hallintotuomioistuin", "hallintotuomioistuimelle")
-  } else {
-    hallintoOikeus.replace("hallinto-oikeus", "hallinto-oikeudelle")
-  }
-}
-
-private def getCommonPaatosValitusoikeusText(lang: String, hallintoOikeus: String): String = lang match {
-  case "finnish" =>
-    s"""<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla ${parseHallintoOikeusName(
-        hallintoOikeus
-      )}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>"""
-  case _ =>
-    s"""<strong>Besvärsrätt</strong><p>Ändring i detta beslut får sökas genom besvär hos $hallintoOikeus. Besvärstiden och förfarandet framgår av bifogade besvärsanvisning.</p>"""
-}
-
-private def getCommonMaksunOikaisuText(lang: String, isPeruutus: Boolean = false): String = {
-
-  val paatosMaksu = (lang, isPeruutus) match {
-    case (_, true)          => ""
-    case ("finnish", false) => "<p>Päätösmaksu 395 euroa</p>"
-    case _                  => "<p>Beslutsavgift 395 euro</p>"
-  }
-  lang match {
-    case "finnish" =>
-      s"""<strong>Maksun oikaisu</strong><p>Päätöksestä perityt maksut perustuvat opetus- ja kulttuuriministeriön asetukseen Opetushallituksen ja sen erillisyksiköiden suoritteiden maksullisuudesta (1508/2025, 1 ja 2 §). Maksuihin voi vaatia oikaisua Opetushallitukselta. Liitteenä olevasta oikaisuvaatimusosoituksesta ilmenee oikaisuvaatimuksen määräaika ja se, miten oikaisua vaadittaessa on meneteltävä.</p><p>Käsittelymaksu 100 euroa</p>$paatosMaksu"""
-    case _ =>
-      s"""<strong>Omprövning som berör avgifterna</strong><p>Avgifterna för beslutet baserar sig på undervisnings- och kulturministeriets förordning om Utbildningsstyrelsens och dess fristående enheters avgiftsbelagda prestationer (1508/2025, 1 och 2 §). Omprövning som berör avgifterna kan begäras av Utbildningsstyrelsen. Av bifogade anvisning för begäran om omprövning framgår tiden för begäran om omprövning och ansökningsförfarandet.</p><p>Behandlingsavgift 100 euro</p>$paatosMaksu"""
-  }
-}
-
-private def getSelectTutkintoTasoText(lang: String): String = lang match {
-  case "finnish" => "<p>Valitse tutkinnon taso.</p>"
-  case _         => "<p>Välj kvalifikationsnivå.</p>"
-}
-
-private def getTutkinto(tutkinnot: Seq[Tutkinto], paatosTieto: PaatosTieto): Option[Tutkinto] = {
-  tutkinnot.find(tutkinto => tutkinto.id == paatosTieto.tutkintoId)
-}
-
-private def getTutkintoNimi(lang: String, tutkinnot: Seq[Tutkinto], paatosTieto: PaatosTieto): Option[String] = {
-  for {
-    tutkinto <- getTutkinto(tutkinnot, paatosTieto) if paatosTieto.lisaaTutkintoPaatostekstiin.getOrElse(false)
-    nimi     <-
-      if (tutkinto.jarjestys == "MUU") Some(if (lang == "finnish") "Muu tutkinto" else "Annan examen")
-      else tutkinto.nimi
-  } yield nimi
-}
-
-private def generateTasoPaatosTeksti(
-  hakemus: Hakemus,
-  tutkinnot: Seq[Tutkinto],
-  paatos: Paatos,
-  paatosKieli: String
-): String = {
-  val tasoPaatosTiedot = paatos.paatosTiedot.filter(_.paatosTyyppi.get == PaatosTyyppi.Taso)
-
-  val tutkintoTexts = tasoPaatosTiedot
-    .map { pt =>
-      if (pt.tutkintoTaso.isDefined)
-        getTasoPaatosTutkintoText(paatosKieli, pt.tutkintoTaso.get, getTutkintoNimi(paatosKieli, tutkinnot, pt))
-      else if (pt.myonteinenPaatos.contains(false)) {
-        paatosKieli match {
-          case "finnish" =>
-            "<p>Hakijan suorittamaa tutkintoa ei rinnasteta Suomessa suoritettavaan korkeakoulututkintoon.</p>"
-          case _ =>
-            "<p>Den examen som den sökande har avlagt jämställs inte med en högskoleexamen som avläggs i Finland.</p>"
-        }
-      } else
-        getSelectTutkintoTasoText(paatosKieli)
+  private def parseHallintoOikeusName(hallintoOikeus: String): String = {
+    if (hallintoOikeus.contains("hallintotuomioistuin")) {
+      hallintoOikeus.replace("hallintotuomioistuin", "hallintotuomioistuimelle")
+    } else {
+      hallintoOikeus.replace("hallinto-oikeus", "hallinto-oikeudelle")
     }
-    .mkString("")
-
-  val perusteluBodies = tasoPaatosTiedot
-    .flatMap { pt =>
-      if (pt.myonteinenPaatos.contains(false)) { // Kielteinen paatos
-        pt.kielteisenPaatoksenPerustelut.toList.flatMap { kp =>
-          kp.productElementNames
-            .zip(kp.productIterator)
-            .collect {
-              case (perusteluNimi, perusteluArvo: Boolean) if perusteluArvo =>
-                val perusteluTeksti = perusteluNimi match {
-                  case "epavirallinenKorkeakoulu" =>
-                    "Epävirallinen korkeakoulu"
-                  case "epavirallinenTutkinto" =>
-                    "Epävirallinen tutkinto"
-                  case "eiVastaaSuomessaSuoritettavaaTutkintoa" =>
-                    "Ei vastaa Suomessa suoritettavaa tutkintoa"
-                  case "muuPerustelu" =>
-                    s"Muu perustelu: ${kp.muuPerusteluKuvaus.getOrElse("")}"
-                  case _ => ""
-                }
-                s"<p>$perusteluTeksti</p>"
-            }
-        }
-      } else
-        pt.tutkintoTaso
-          .map(taso => getTasoPaatosPerusteluBodyText(paatosKieli, taso, getTutkintoNimi(paatosKieli, tutkinnot, pt)))
-    }
-    .mkString("")
-
-  getTasoPaatosHeader(paatosKieli, tasoPaatosTiedot.size)
-    ++ tutkintoTexts
-    ++ getTasoPaatosPerusteluHeader(paatosKieli)
-    ++ perusteluBodies
-    ++ getTasoPaatosLakiText(paatosKieli)
-}
-
-private def generatePeruutusTeksti(lang: String, hakemus: Hakemus): String = {
-  val peruutusPvm = hakemus.peruutusPvm match {
-    case Some(date) => formatDate(date)
-    case _          => if (lang == "finnish") "[pp.kk.vvvv]" else "[dd.mm.åååå]"
   }
-  lang match {
-    case "finnish" =>
-      s"""<strong>Päätös</strong><p>Hakija on peruuttanut hakemuksensa $peruutusPvm. Hakemuksen käsittely raukeaa.</p>"""
+
+  private def getCommonPaatosValitusoikeusText(lang: Kieli, hallintoOikeus: String): String = lang match {
+    case Kieli.fi =>
+      s"""<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla ${parseHallintoOikeusName(
+          hallintoOikeus
+        )}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>"""
     case _ =>
-      s"""<strong>Beslut</strong><p>Den sökande har dragit tillbaka sin ansökan $peruutusPvm. Behandlingen av ansökan förfaller.</p>"""
-  }
-}
-
-private def getTODOText(lang: String): String = lang match {
-  case "finnish" =>
-    s"""<p>Tällä hetkellä esikatselua ei ole saatavilla.</p>"""
-  case _ =>
-    s"""<p>Det finns för närvarande ingen förhandsvisning tillgänglig.</p>"""
-}
-
-def generatePaatosTeksti(
-  hakemus: Hakemus,
-  tutkinnot: Seq[Tutkinto],
-  paatos: Paatos,
-  paatosKieli: String,
-  hallintoOikeus: HallintoOikeus,
-  maakoodiService: MaakoodiService
-): String = {
-  val hallintoOikeudenNimi = paatosKieli match {
-    case "finnish" => hallintoOikeus.nimi.get(Kieli.fi)
-    case _         => hallintoOikeus.nimi.get(Kieli.sv)
+      s"""<strong>Besvärsrätt</strong><p>Ändring i detta beslut får sökas genom besvär hos $hallintoOikeus. Besvärstiden och förfarandet framgår av bifogade besvärsanvisning.</p>"""
   }
 
-  val containsTasoPaatos =
-    paatos.paatosTiedot.exists(paatosTieto => paatosTieto.paatosTyyppi.get == PaatosTyyppi.Taso)
+  private def getCommonMaksunOikaisuText(lang: Kieli, isPeruutus: Boolean = false): String = {
 
-  paatos.ratkaisutyyppi match {
-    case Some(Ratkaisutyyppi.Paatos) =>
-      getCommonPaatosHeader(hakemus, tutkinnot, paatos, paatosKieli, maakoodiService)
-        ++ (containsTasoPaatos match {
-          case true => generateTasoPaatosTeksti(hakemus, tutkinnot, paatos, paatosKieli)
-          case _    => getTODOText(paatosKieli)
-        })
-        ++ getCommonPaatosValitusoikeusText(paatosKieli, hallintoOikeudenNimi.get)
-        ++ getCommonMaksunOikaisuText(paatosKieli)
-    case Some(Ratkaisutyyppi.PeruutusTaiRaukeaminen) =>
-      getCommonPaatosHeader(hakemus, tutkinnot, paatos, paatosKieli, maakoodiService)
-        ++ generatePeruutusTeksti(paatosKieli, hakemus)
-        ++ getCommonMaksunOikaisuText(paatosKieli, isPeruutus = true)
-    case _ => getTODOText(paatosKieli)
+    val paatosMaksu = (lang, isPeruutus) match {
+      case (_, true)         => ""
+      case (Kieli.fi, false) => "<p>Päätösmaksu 395 euroa</p>"
+      case _                 => "<p>Beslutsavgift 395 euro</p>"
+    }
+    lang match {
+      case Kieli.fi =>
+        s"""<strong>Maksun oikaisu</strong><p>Päätöksestä perityt maksut perustuvat opetus- ja kulttuuriministeriön asetukseen Opetushallituksen ja sen erillisyksiköiden suoritteiden maksullisuudesta (1508/2025, 1 ja 2 §). Maksuihin voi vaatia oikaisua Opetushallitukselta. Liitteenä olevasta oikaisuvaatimusosoituksesta ilmenee oikaisuvaatimuksen määräaika ja se, miten oikaisua vaadittaessa on meneteltävä.</p><p>Käsittelymaksu 100 euroa</p>$paatosMaksu"""
+      case _ =>
+        s"""<strong>Omprövning som berör avgifterna</strong><p>Avgifterna för beslutet baserar sig på undervisnings- och kulturministeriets förordning om Utbildningsstyrelsens och dess fristående enheters avgiftsbelagda prestationer (1508/2025, 1 och 2 §). Omprövning som berör avgifterna kan begäras av Utbildningsstyrelsen. Av bifogade anvisning för begäran om omprövning framgår tiden för begäran om omprövning och ansökningsförfarandet.</p><p>Behandlingsavgift 100 euro</p>$paatosMaksu"""
+    }
+  }
+
+  private def getSelectTutkintoTasoText(lang: Kieli): String = lang match {
+    case Kieli.fi => "<p>Valitse tutkinnon taso.</p>"
+    case _        => "<p>Välj kvalifikationsnivå.</p>"
+  }
+
+  private def getTutkinto(tutkinnot: Seq[Tutkinto], paatosTieto: PaatosTieto): Option[Tutkinto] = {
+    tutkinnot.find(tutkinto => tutkinto.id == paatosTieto.tutkintoId)
+  }
+
+  private def getTutkintoNimi(lang: Kieli, tutkinnot: Seq[Tutkinto], paatosTieto: PaatosTieto): Option[String] = {
+    for {
+      tutkinto <- getTutkinto(tutkinnot, paatosTieto) if paatosTieto.lisaaTutkintoPaatostekstiin.getOrElse(false)
+      nimi     <-
+        if (tutkinto.jarjestys == "MUU") Some(if (lang == Kieli.fi) "Muu tutkinto" else "Annan examen")
+        else tutkinto.nimi
+    } yield nimi
+  }
+
+  private def generateTasoPaatosTeksti(
+    hakemus: Hakemus,
+    tutkinnot: Seq[Tutkinto],
+    paatos: Paatos,
+    paatosKieli: Kieli
+  ): String = {
+    val tasoPaatosTiedot = paatos.paatosTiedot.filter(_.paatosTyyppi.get == PaatosTyyppi.Taso)
+
+    val tutkintoTexts = tasoPaatosTiedot
+      .map { pt =>
+        if (pt.tutkintoTaso.isDefined)
+          getTasoPaatosTutkintoText(paatosKieli, pt.tutkintoTaso.get, getTutkintoNimi(paatosKieli, tutkinnot, pt))
+        else if (pt.myonteinenPaatos.contains(false)) {
+          paatosKieli match {
+            case Kieli.fi =>
+              "<p>Hakijan suorittamaa tutkintoa ei rinnasteta Suomessa suoritettavaan korkeakoulututkintoon.</p>"
+            case _ =>
+              "<p>Den examen som den sökande har avlagt jämställs inte med en högskoleexamen som avläggs i Finland.</p>"
+          }
+        } else
+          getSelectTutkintoTasoText(paatosKieli)
+      }
+      .mkString("")
+
+    val perusteluBodies = tasoPaatosTiedot
+      .flatMap { pt =>
+        if (pt.myonteinenPaatos.contains(false)) { // Kielteinen paatos
+          pt.kielteisenPaatoksenPerustelut.toList.flatMap { kp =>
+            kp.productElementNames
+              .zip(kp.productIterator)
+              .collect {
+                case (perusteluNimi, perusteluArvo: Boolean) if perusteluArvo =>
+                  val perusteluTeksti = perusteluNimi match {
+                    case "epavirallinenKorkeakoulu" =>
+                      "Epävirallinen korkeakoulu"
+                    case "epavirallinenTutkinto" =>
+                      "Epävirallinen tutkinto"
+                    case "eiVastaaSuomessaSuoritettavaaTutkintoa" =>
+                      "Ei vastaa Suomessa suoritettavaa tutkintoa"
+                    case "muuPerustelu" =>
+                      s"Muu perustelu: ${kp.muuPerusteluKuvaus.getOrElse("")}"
+                    case _ => ""
+                  }
+                  s"<p>$perusteluTeksti</p>"
+              }
+          }
+        } else
+          pt.tutkintoTaso
+            .map(taso => getTasoPaatosPerusteluBodyText(paatosKieli, taso, getTutkintoNimi(paatosKieli, tutkinnot, pt)))
+      }
+      .mkString("")
+
+    getTasoPaatosHeader(paatosKieli, tasoPaatosTiedot.size)
+      ++ tutkintoTexts
+      ++ getTasoPaatosPerusteluHeader(paatosKieli)
+      ++ perusteluBodies
+      ++ getTasoPaatosLakiText(paatosKieli)
+  }
+
+  private def generatePeruutusTeksti(lang: Kieli, hakemus: Hakemus): String = {
+    val peruutusPvm = hakemus.peruutusPvm match {
+      case Some(date) => formatDate(date)
+      case _          => if (lang == Kieli.fi) "[pp.kk.vvvv]" else "[dd.mm.åååå]"
+    }
+    lang match {
+      case Kieli.fi =>
+        s"""<strong>Päätös</strong><p>Hakija on peruuttanut hakemuksensa $peruutusPvm. Hakemuksen käsittely raukeaa.</p>"""
+      case _ =>
+        s"""<strong>Beslut</strong><p>Den sökande har dragit tillbaka sin ansökan $peruutusPvm. Behandlingen av ansökan förfaller.</p>"""
+    }
+  }
+
+  private def getTODOText(lang: Kieli): String = lang match {
+    case Kieli.fi =>
+      s"""<p>Tällä hetkellä esikatselua ei ole saatavilla.</p>"""
+    case _ =>
+      s"""<p>Det finns för närvarande ingen förhandsvisning tillgänglig.</p>"""
+  }
+
+  def generatePaatosTeksti(
+    hakemus: Hakemus,
+    tutkinnot: Seq[Tutkinto],
+    paatos: Paatos,
+    paatosKieli: Kieli,
+    hallintoOikeus: HallintoOikeus,
+    maakoodiService: MaakoodiService
+  ): String = {
+    val hallintoOikeudenNimi = hallintoOikeus.nimi.get(paatosKieli)
+
+    val containsTasoPaatos =
+      paatos.paatosTiedot.exists(paatosTieto => paatosTieto.paatosTyyppi.get == PaatosTyyppi.Taso)
+
+    paatos.ratkaisutyyppi match {
+      case Some(Ratkaisutyyppi.Paatos) =>
+        getCommonPaatosHeader(hakemus, tutkinnot, paatos, paatosKieli, maakoodiService)
+          ++ (containsTasoPaatos match {
+            case true => generateTasoPaatosTeksti(hakemus, tutkinnot, paatos, paatosKieli)
+            case _    => getTODOText(paatosKieli)
+          })
+          ++ getCommonPaatosValitusoikeusText(paatosKieli, hallintoOikeudenNimi.get)
+          ++ getCommonMaksunOikaisuText(paatosKieli)
+      case Some(Ratkaisutyyppi.PeruutusTaiRaukeaminen) =>
+        getCommonPaatosHeader(hakemus, tutkinnot, paatos, paatosKieli, maakoodiService)
+          ++ generatePeruutusTeksti(paatosKieli, hakemus)
+          ++ getCommonMaksunOikaisuText(paatosKieli, isPeruutus = true)
+      case _ => getTODOText(paatosKieli)
+    }
   }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/paatosteksti/PaatosTekstiGenerator.scala
@@ -30,7 +30,7 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     hakemus: Hakemus,
     tutkinnot: Seq[Tutkinto],
     paatos: Paatos,
-    paatosKieli: Kieli,
+    lang: Kieli,
     maakoodiService: MaakoodiService
   ): String = {
     val hakijaNimi        = s"${hakemus.hakija.sukunimi} ${hakemus.hakija.etunimet}"
@@ -60,7 +60,7 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
               .flatMap(maakoodiUri =>
                 maakoodiService
                   .getMaakoodiByUri(maakoodiUri)
-                  .flatMap(m => Some(if (paatosKieli == Kieli.fi) m.fi else m.sv))
+                  .flatMap(m => Some(if (lang == Kieli.fi) m.fi else m.sv))
               )
               .getOrElse("")
 
@@ -77,10 +77,13 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
             )
 
             if (tutkintoParts.nonEmpty) { // Filtteröi esim. Muut tutkinnot pois
-              if (paatosKieli == Kieli.fi)
-                s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Todistuksen päivämäärä: $todistuksenPaivamaara</p>"""
-              else
-                s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>Datum för bevis: $todistuksenPaivamaara</p>"""
+              s"""<p>${tutkintoOtsikkoLabel}:</p><p>$tutkintoParts<br>"""
+                + translationService.getTranslation(
+                  lang,
+                  "paatosteksti.todistuksenPaivamaara",
+                  Map("paivamaara" -> todistuksenPaivamaara)
+                )
+                + "</p>"
             } else {
               ""
             }
@@ -88,12 +91,12 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
           .mkString("")
       }
 
-    paatosKieli match {
-      case Kieli.fi =>
-        s"""<p>Hakija:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
-      case _ =>
-        s"""<p>Sökande:</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
-    }
+    "<p>"
+      + translationService.getTranslation(
+        lang,
+        "paatosteksti.hakija"
+      )
+      + s"""</p><p>$hakijaNimi<br>$hakijaSyntymaaika</p>$tutkintoBlocks"""
   }
 
   private def getTasoPaatosHeader(lang: Kieli, count: Number): String = lang match {
@@ -119,7 +122,7 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     val koulu    = getKorkeakouluTasoText(lang, tutkintoTaso)
     translationService.getTranslation(
       lang,
-      "paatosteksti.tasoPaatosTutkinto",
+      "paatosteksti.tasoPaatos.myonteinen",
       Map("tutkintoNimi" -> tutkinto, "koulu" -> koulu)
     )
   }
@@ -138,9 +141,8 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     )
   }
 
-  private def getTasoPaatosPerusteluHeader(lang: Kieli): String = lang match {
-    case Kieli.fi => "<strong>Perustelu</strong>"
-    case _        => "<strong>Motivering</strong>"
+  private def getTasoPaatosPerusteluHeader(lang: Kieli): String = {
+    translationService.getTranslation(lang, "paatosteksti.tasoPaatosPerusteluHeader")
   }
 
   private def getTasoPaatosLakiText(lang: Kieli): String = {
@@ -168,9 +170,8 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     translationService.getTranslation(lang, "paatosteksti.maksunOikaisu", Map("paatosMaksu" -> paatosMaksu))
   }
 
-  private def getSelectTutkintoTasoText(lang: Kieli): String = lang match {
-    case Kieli.fi => "<p>Valitse tutkinnon taso.</p>"
-    case _        => "<p>Välj kvalifikationsnivå.</p>"
+  private def getSelectTutkintoTasoText(lang: Kieli): String = {
+    translationService.getTranslation(lang, "paatosteksti.tutkinnonTaso.valitse")
   }
 
   private def getTutkinto(tutkinnot: Seq[Tutkinto], paatosTieto: PaatosTieto): Option[Tutkinto] = {
@@ -181,7 +182,8 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     for {
       tutkinto <- getTutkinto(tutkinnot, paatosTieto) if paatosTieto.lisaaTutkintoPaatostekstiin.getOrElse(false)
       nimi     <-
-        if (tutkinto.jarjestys == "MUU") Some(if (lang == Kieli.fi) "Muu tutkinto" else "Annan examen")
+        if (tutkinto.jarjestys == "MUU")
+          Some(translationService.getTranslation(lang, "paatosteksti.muuTutkinto"))
         else tutkinto.nimi
     } yield nimi
   }
@@ -190,23 +192,18 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
     hakemus: Hakemus,
     tutkinnot: Seq[Tutkinto],
     paatos: Paatos,
-    paatosKieli: Kieli
+    lang: Kieli
   ): String = {
     val tasoPaatosTiedot = paatos.paatosTiedot.filter(_.paatosTyyppi.get == PaatosTyyppi.Taso)
 
     val tutkintoTexts = tasoPaatosTiedot
       .map { pt =>
         if (pt.tutkintoTaso.isDefined)
-          getTasoPaatosTutkintoText(paatosKieli, pt.tutkintoTaso.get, getTutkintoNimi(paatosKieli, tutkinnot, pt))
+          getTasoPaatosTutkintoText(lang, pt.tutkintoTaso.get, getTutkintoNimi(lang, tutkinnot, pt))
         else if (pt.myonteinenPaatos.contains(false)) {
-          paatosKieli match {
-            case Kieli.fi =>
-              "<p>Hakijan suorittamaa tutkintoa ei rinnasteta Suomessa suoritettavaan korkeakoulututkintoon.</p>"
-            case _ =>
-              "<p>Den examen som den sökande har avlagt jämställs inte med en högskoleexamen som avläggs i Finland.</p>"
-          }
+          translationService.getTranslation(lang, "paatosteksti.tasoPaatos.kielteinen")
         } else
-          getSelectTutkintoTasoText(paatosKieli)
+          getSelectTutkintoTasoText(lang)
       }
       .mkString("")
 
@@ -234,15 +231,15 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
           }
         } else
           pt.tutkintoTaso
-            .map(taso => getTasoPaatosPerusteluBodyText(paatosKieli, taso, getTutkintoNimi(paatosKieli, tutkinnot, pt)))
+            .map(taso => getTasoPaatosPerusteluBodyText(lang, taso, getTutkintoNimi(lang, tutkinnot, pt)))
       }
       .mkString("")
 
-    getTasoPaatosHeader(paatosKieli, tasoPaatosTiedot.size)
+    getTasoPaatosHeader(lang, tasoPaatosTiedot.size)
       ++ tutkintoTexts
-      ++ getTasoPaatosPerusteluHeader(paatosKieli)
+      ++ getTasoPaatosPerusteluHeader(lang)
       ++ perusteluBodies
-      ++ getTasoPaatosLakiText(paatosKieli)
+      ++ getTasoPaatosLakiText(lang)
   }
 
   private def generatePeruutusTeksti(lang: Kieli, hakemus: Hakemus): String = {
@@ -250,19 +247,11 @@ class PaatosTekstiGenerator(translationService: TranslationService) {
       case Some(date) => formatDate(date)
       case _          => if (lang == Kieli.fi) "[pp.kk.vvvv]" else "[dd.mm.åååå]"
     }
-    lang match {
-      case Kieli.fi =>
-        s"""<strong>Päätös</strong><p>Hakija on peruuttanut hakemuksensa $peruutusPvm. Hakemuksen käsittely raukeaa.</p>"""
-      case _ =>
-        s"""<strong>Beslut</strong><p>Den sökande har dragit tillbaka sin ansökan $peruutusPvm. Behandlingen av ansökan förfaller.</p>"""
-    }
+    translationService.getTranslation(lang, "paatosteksti.peruutus", Map("peruutusPvm" -> peruutusPvm))
   }
 
-  private def getTODOText(lang: Kieli): String = lang match {
-    case Kieli.fi =>
-      s"""<p>Tällä hetkellä esikatselua ei ole saatavilla.</p>"""
-    case _ =>
-      s"""<p>Det finns för närvarande ingen förhandsvisning tillgänglig.</p>"""
+  private def getTODOText(lang: Kieli): String = {
+    translationService.getTranslation(lang, "paatosteksti.todo")
   }
 
   def generatePaatosTeksti(

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/perustelumuistio/PerusteluMuistioGenerator.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/perustelumuistio/PerusteluMuistioGenerator.scala
@@ -8,13 +8,15 @@ import fi.oph.tutu.backend.service.{KoodistoService, MaakoodiService, OnrService
 import fi.oph.tutu.backend.service.generator.{formatDate, toKyllaEi}
 import fi.oph.tutu.backend.utils.{Constants, Utility, haeKysymyksenTiedot}
 
+val FI = Kieli.fi
+
 def haeImiPyyntoTieto(translationService: TranslationService, hakemusMaybe: Option[Hakemus]): Option[String] = {
   val imiPyynto: Option[ImiPyynto] = hakemusMaybe.flatMap(_.asiakirja).map(_.imiPyynto)
   val showImiData                  = imiPyynto.flatMap(_.imiPyynto).contains(true)
 
   if (showImiData) {
-    val imiPyyntoLabel = translationService.getTranslation("fi", "perustelumuistio.imipyynto.label")
-    val vastattuLabel  = translationService.getTranslation("fi", "perustelumuistio.imipyynto.vastattu.label")
+    val imiPyyntoLabel = translationService.getTranslation(FI, "perustelumuistio.imipyynto.label")
+    val vastattuLabel  = translationService.getTranslation(FI, "perustelumuistio.imipyynto.vastattu.label")
 
     val imiPyyntoNumero   = imiPyynto.flatMap(_.getNumeroIfPyyntoTrue).getOrElse(" - ")
     val imiPyyntoVastattu = imiPyynto
@@ -42,11 +44,14 @@ def haeValmistuminenVahvistettu(
       .flatMap(_.getVastausIfVahvistusTrue)
       .map {
         case ValmistumisenVahvistusVastaus.Myonteinen =>
-          translationService.getTranslation("fi", "perustelumuistio.valmistuminenVahvistettu.vastaus.myonteinen")
+          translationService.getTranslation(FI, "perustelumuistio.valmistuminenVahvistettu.vastaus.myonteinen")
         case ValmistumisenVahvistusVastaus.Kielteinen =>
-          translationService.getTranslation("fi", "perustelumuistio.valmistuminenVahvistettu.vastaus.kielteinen")
+          translationService.getTranslation(FI, "perustelumuistio.valmistuminenVahvistettu.vastaus.kielteinen")
         case ValmistumisenVahvistusVastaus.EiVastausta =>
-          translationService.getTranslation("fi", "perustelumuistio.valmistuminenVahvistettu.vastaus.vastaustaEiSaatu")
+          translationService.getTranslation(
+            FI,
+            "perustelumuistio.valmistuminenVahvistettu.vastaus.vastaustaEiSaatu"
+          )
       }
   muotoiltuVastausMaybe
 }
@@ -57,9 +62,9 @@ def haeSelvityksetSaatu(translationService: TranslationService, hakemusMaybe: Op
     .map(_.selvityksetSaatu)
     .map {
       case true =>
-        translationService.getTranslation("fi", "perustelumuistio.selvityksetSaatu.vastaus.kylla")
+        translationService.getTranslation(FI, "perustelumuistio.selvityksetSaatu.vastaus.kylla")
       case false =>
-        translationService.getTranslation("fi", "perustelumuistio.selvityksetSaatu.vastaus.ei")
+        translationService.getTranslation(FI, "perustelumuistio.selvityksetSaatu.vastaus.ei")
     }
 }
 
@@ -72,21 +77,21 @@ def haeSuostumusSahkoiseenAsiointiin(
     .flatMap(_.value.head.label.get(Kieli.fi))
 
   suostumusValue.map(valinta => {
-    val label = translationService.getTranslation("fi", "perustelumuistio.suostumusSahkoiseenAsiointiin.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.suostumusSahkoiseenAsiointiin.label")
     s"$label $valinta".trim
   })
 }
 
 def haeHakijanNimi(translationService: TranslationService, hakemusMaybe: Option[Hakemus]): Option[String] = {
   hakemusMaybe.map(hakemus => {
-    val label = translationService.getTranslation("fi", "perustelumuistio.hakijanNimi.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.hakijanNimi.label")
     s"$label ${hakemus.hakija.kutsumanimi} ${hakemus.hakija.sukunimi}".trim
   })
 }
 
 def haeHakijanSyntymaaika(translationService: TranslationService, hakemusMaybe: Option[Hakemus]): Option[String] = {
   hakemusMaybe.map(hakemus => {
-    val label = translationService.getTranslation("fi", "perustelumuistio.hakijanSyntymaaika.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.hakijanSyntymaaika.label")
     s"$label ${hakemus.hakija.syntymaaika}".trim
   })
 }
@@ -125,7 +130,7 @@ def haeHakemusKoskee(translationService: TranslationService, hakemusMaybe: Optio
   if (hakemusMaybe.isEmpty) {
     None
   } else {
-    val label   = translationService.getTranslation("fi", "perustelumuistio.hakemusKoskee.label")
+    val label   = translationService.getTranslation(FI, "perustelumuistio.hakemusKoskee.label")
     val hakemus = hakemusMaybe.get
 
     val hakemuksenKieli: Kieli = hakemus.lomakkeenKieli match {
@@ -153,7 +158,7 @@ def haeHakemusKoskee(translationService: TranslationService, hakemusMaybe: Optio
 }
 
 def haeMuuTutkinto(translationService: TranslationService, tutkinnot: Seq[Tutkinto]): Option[String] = {
-  val label                              = translationService.getTranslation("fi", "perustelumuistio.muuTutkinto.label")
+  val label                              = translationService.getTranslation(FI, "perustelumuistio.muuTutkinto.label")
   val muuTutkintoMaybe: Option[Tutkinto] = tutkinnot.find((tutkinto: Tutkinto) => tutkinto.jarjestys == "MUU")
   val muuTutkintoTietoMaybe: Option[String] = muuTutkintoMaybe.flatMap(_.muuTutkintoTieto)
 
@@ -161,7 +166,7 @@ def haeMuuTutkinto(translationService: TranslationService, tutkinnot: Seq[Tutkin
 }
 
 def haeYhteistutkinto(translationService: TranslationService, hakemusMaybe: Option[Hakemus]): Option[String] = {
-  val value = translationService.getTranslation("fi", "perustelumuistio.yhteistutkinto.value")
+  val value = translationService.getTranslation(FI, "perustelumuistio.yhteistutkinto.value")
   hakemusMaybe.flatMap(hakemus =>
     if (hakemus.yhteistutkinto) { Some(value) }
     else { None }
@@ -223,14 +228,15 @@ def haePerustelunTutkintokohtaisetTiedot(
     .filter((tutkinto: Tutkinto) => tutkinto.jarjestys != "MUU")
     .sortWith((a: Tutkinto, b: Tutkinto) => a.jarjestys.toInt < b.jarjestys.toInt)
     .map((tutkinto: Tutkinto) => {
-      val suoritusvuodetLabel     = translationService.getTranslation("fi", "perustelumuistio.suoritusvuodet.label")
-      val ohjeellinenLaajuusLabel = translationService.getTranslation("fi", "perustelumuistio.ohjeellinenLaajuus.label")
+      val suoritusvuodetLabel     = translationService.getTranslation(FI, "perustelumuistio.suoritusvuodet.label")
+      val ohjeellinenLaajuusLabel =
+        translationService.getTranslation(FI, "perustelumuistio.ohjeellinenLaajuus.label")
       val tutkintoonSisaltyiOpinnaytetyoLabel =
-        translationService.getTranslation("fi", "perustelumuistio.tutkintoonSisaltyiOpinnayte.label")
+        translationService.getTranslation(FI, "perustelumuistio.tutkintoonSisaltyiOpinnayte.label")
       val tutkintoonSisaltyiHarjoitteluLabel =
-        translationService.getTranslation("fi", "perustelumuistio.tutkintoonSisaltyiHarjoittelu.label")
+        translationService.getTranslation(FI, "perustelumuistio.tutkintoonSisaltyiHarjoittelu.label")
       val lisatietoaOpinnaytteisiinJaHArjoitteluunLabel =
-        translationService.getTranslation("fi", "perustelumuistio.lisatietoaOpinnaytteeseenJaHarjoitteluun.label")
+        translationService.getTranslation(FI, "perustelumuistio.lisatietoaOpinnaytteeseenJaHarjoitteluun.label")
 
       val suoritusvuodet = Seq(tutkinto.aloitusVuosi, tutkinto.paattymisVuosi).flatten
         .mkString(" - ")
@@ -259,38 +265,38 @@ def haeYleisetPerustelut(translationService: TranslationService, perusteluMaybe:
         perustelu.virallinenTutkinnonMyontaja
           .map {
             case true =>
-              translationService.getTranslation("fi", "perustelumuistio.virallinenTutkinnonMyontaja.kylla")
+              translationService.getTranslation(FI, "perustelumuistio.virallinenTutkinnonMyontaja.kylla")
             case false =>
-              translationService.getTranslation("fi", "perustelumuistio.virallinenTutkinnonMyontaja.ei")
+              translationService.getTranslation(FI, "perustelumuistio.virallinenTutkinnonMyontaja.ei")
           },
         perustelu.virallinenTutkinto
           .map {
             case true =>
-              translationService.getTranslation("fi", "perustelumuistio.virallinenTutkinto.kylla")
+              translationService.getTranslation(FI, "perustelumuistio.virallinenTutkinto.kylla")
             case false =>
-              translationService.getTranslation("fi", "perustelumuistio.virallinenTutkinto.ei")
+              translationService.getTranslation(FI, "perustelumuistio.virallinenTutkinto.ei")
           },
         if (perustelu.lahdeLahtomaanKansallinenLahde) {
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.lahdeLahtomaanKansallinenLahde.value")
+            translationService.getTranslation(FI, "perustelumuistio.lahdeLahtomaanKansallinenLahde.value")
           )
         } else None,
         if (perustelu.lahdeLahtomaanVirallinenVastaus) {
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.lahdeLahtomaanVirallinenVastaus.value")
+            translationService.getTranslation(FI, "perustelumuistio.lahdeLahtomaanVirallinenVastaus.value")
           )
         } else None,
         if (perustelu.lahdeKansainvalinenHakuteosTaiVerkkosivusto) {
           Some(
             translationService.getTranslation(
-              "fi",
+              FI,
               "perustelumuistio.lahdeKansainvalinenHakuteosTaiVerkkosivusto.value"
             )
           )
         } else None,
         if (perustelu.selvitysTutkinnonMyontajastaJaTutkinnonVirallisuudesta != "") {
           val label = translationService.getTranslation(
-            "fi",
+            FI,
             "perustelumuistio.selvitysTutkinnonMyontajastaJaTutkinnonVirallisuudesta.label"
           )
           Some(
@@ -301,33 +307,33 @@ def haeYleisetPerustelut(translationService: TranslationService, perusteluMaybe:
           .map {
             case "alempi_korkeakouluaste" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.ylimmanTutkinnonAsemaLahtomaanJarjestelmassa.alempi_korkeakouluaste"
               )
             case "ylempi_korkeakouluaste" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.ylimmanTutkinnonAsemaLahtomaanJarjestelmassa.ylempi_korkeakouluaste"
               )
             case "alempi_ja_ylempi_korkeakouluaste" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.ylimmanTutkinnonAsemaLahtomaanJarjestelmassa.alempi_ja_ylempi_korkeakouluaste"
               )
             case "tutkijakoulutusaste" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.ylimmanTutkinnonAsemaLahtomaanJarjestelmassa.tutkijakoulutusaste"
               )
             case "ei_korkeakouluaste" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.ylimmanTutkinnonAsemaLahtomaanJarjestelmassa.ei_korkeakouluaste"
               )
           },
         if (perustelu.selvitysTutkinnonAsemastaLahtomaanJarjestelmassa != "") {
           val label = translationService.getTranslation(
-            "fi",
+            FI,
             "perustelumuistio.selvitysTutkinnonAsemastaLahtomaanJarjestelmassa.label"
           )
           Some(
@@ -355,21 +361,21 @@ def haeJatkoOpintoKelpoisuus(
           .map {
             case "toisen_vaiheen_korkeakouluopintoihin" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.jatkoOpintoKelpoisuus.toisen_vaiheen_korkeakouluopintoihin"
               )
             case "tieteellisiin_jatko-opintoihin" =>
               translationService.getTranslation(
-                "fi",
+                FI,
                 "perustelumuistio.jatkoOpintoKelpoisuus.tieteellisiin_jatko-opintoihin"
               )
             case "muu" =>
-              translationService.getTranslation("fi", "perustelumuistio.jatkoOpintoKelpoisuus.muu")
+              translationService.getTranslation(FI, "perustelumuistio.jatkoOpintoKelpoisuus.muu")
           },
         (perustelu.jatkoOpintoKelpoisuus, perustelu.jatkoOpintoKelpoisuusLisatieto) match {
           case (Some("muu"), Some(lisatieto)) => {
             val label =
-              translationService.getTranslation("fi", "perustelumuistio.jatkoOpintoKelpoisuus.lisatieto.label")
+              translationService.getTranslation(FI, "perustelumuistio.jatkoOpintoKelpoisuus.lisatieto.label")
             Some(s"$label\n$lisatieto")
           }
           case (_, _) => None
@@ -390,8 +396,8 @@ def haeAikaisemmatPaatokset(
   perusteluMaybe.flatMap(perustelu => {
     perustelu.aikaisemmatPaatokset
       .map {
-        case true  => translationService.getTranslation("fi", "perustelumuistio.aikaisemmatPaatokset.kylla")
-        case false => translationService.getTranslation("fi", "perustelumuistio.aikaisemmatPaatokset.ei")
+        case true  => translationService.getTranslation(FI, "perustelumuistio.aikaisemmatPaatokset.kylla")
+        case false => translationService.getTranslation(FI, "perustelumuistio.aikaisemmatPaatokset.ei")
       }
   })
 }
@@ -401,7 +407,7 @@ def haeMuuPerustelu(translationService: TranslationService, perusteluMaybe: Opti
     perustelu.muuPerustelu
       .filter(_.nonEmpty)
       .map(muotoiltu => {
-        val label = translationService.getTranslation("fi", "perustelumuistio.muuPerustelu.label")
+        val label = translationService.getTranslation(FI, "perustelumuistio.muuPerustelu.label")
         s"$label\n$muotoiltu"
       })
   })
@@ -414,7 +420,7 @@ def haeUoRoPerustelu(
   val koulutuksenSisalto = perusteluMaybe
     .flatMap(_.uoRoSisalto.koulutuksenSisalto)
     .map(sisalto => {
-      val label = translationService.getTranslation("fi", "perustelumuistio.koulutuksenSisalto.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.koulutuksenSisalto.label")
       s"$label\n$sisalto"
     })
 
@@ -427,78 +433,82 @@ def haeUoRoPerustelu(
         uoRoSisalto.opettajatEroMonialaisetOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.monialaisetSisalto")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.monialaisetSisalto")
           ),
         uoRoSisalto.opettajatEroMonialaisetOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.monialaisetLaajuus")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.monialaisetLaajuus")
           ),
         uoRoSisalto.opettajatEroPedagogisetOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.pedagogisetSisalto")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.pedagogisetSisalto")
           ),
         uoRoSisalto.opettajatEroPedagogisetOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.pedagogisetLaajuus")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.pedagogisetLaajuus")
           ),
         uoRoSisalto.opettajatEroKasvatustieteellisetOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetLaajuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetLaajuus")
           ),
         uoRoSisalto.opettajatEroKasvatustieteellisetOpinnotVaativuus
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetVaativuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetVaativuus")
           ),
         uoRoSisalto.opettajatEroKasvatustieteellisetOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetSisalto")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.kasvatustieteellisetSisalto")
           ),
         uoRoSisalto.opettajatEroOpetettavatAineetOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetSisalto")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetSisalto")
           ),
         uoRoSisalto.opettajatEroOpetettavatAineetOpinnotVaativuus
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetVaativuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetVaativuus")
           ),
         uoRoSisalto.opettajatEroOpetettavatAineetOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetLaajuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.opetettavatAineetLaajuus")
           ),
         uoRoSisalto.opettajatEroErityisopettajanOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.erityisopettajaSisalto")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.erityisopettajaSisalto")
           ),
         uoRoSisalto.opettajatEroErityisopettajanOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.opettajat.erityisopettajaLaajuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.opettajat.erityisopettajaLaajuus")
           ),
         (uoRoSisalto.opettajatMuuEro, uoRoSisalto.opettajatMuuEroSelite) match {
           case (Some(true), Some("")) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), None) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), Some(selite)) => {
-            val label = translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muuLabel")
+            val label = translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muuLabel")
             Some(s"$label\n$selite")
           }
           case (_, _) => None
@@ -510,31 +520,33 @@ def haeUoRoPerustelu(
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.vkopettajat.kasvatustieteellisetLaajuus")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.vkopettajat.kasvatustieteellisetLaajuus")
           ),
         uoRoSisalto.vkOpettajatEroKasvatustieteellisetOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.uoro.koulutuserot.vkopettajat.kasvatustieteellisetSisalto")
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.vkopettajat.kasvatustieteellisetSisalto")
           ),
         uoRoSisalto.vkOpettajatEroVarhaiskasvatusEsiopetusOpinnotLaajuus
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.vkopettajat.opintojenLaajuus")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.vkopettajat.opintojenLaajuus")
           ),
         uoRoSisalto.vkOpettajatEroVarhaiskasvatusEsiopetusOpinnotSisalto
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.vkopettajat.opintojenSisalto")
+            translationService
+              .getTranslation(FI, "perustelumuistio.uoro.koulutuserot.vkopettajat.opintojenSisalto")
           ),
         (uoRoSisalto.vkOpettajatMuuEro, uoRoSisalto.vkOpettajatMuuEroSelite) match {
           case (Some(true), Some("")) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), None) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), Some(selite)) => {
-            val label = translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muuLabel")
+            val label = translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muuLabel")
             Some(s"$label\n$selite")
           }
           case (_, _) => None
@@ -544,22 +556,20 @@ def haeUoRoPerustelu(
         // Oikeustieteen maisterit
         uoRoSisalto.otmEroOpinnotLaajuus
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.otm.opintojenLaajuus")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.otm.opintojenLaajuus")),
         uoRoSisalto.otmEroOpinnotVaativuus
           .filter(_.==(true))
-          .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.otm.opintojenVaativuus")
-          ),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.otm.opintojenVaativuus")),
         uoRoSisalto.otmEroOpinnotSisalto
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.otm.opintojenSisalto")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.otm.opintojenSisalto")),
         (uoRoSisalto.otmMuuEro, uoRoSisalto.otmMuuEroSelite) match {
           case (Some(true), Some("")) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), None) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muu"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muu"))
           case (Some(true), Some(selite)) => {
-            val label = translationService.getTranslation("fi", "perustelumuistio.uoro.koulutuserot.muuLabel")
+            val label = translationService.getTranslation(FI, "perustelumuistio.uoro.koulutuserot.muuLabel")
             Some(s"$label\n$selite")
           }
           case (_, _) => None
@@ -570,7 +580,7 @@ def haeUoRoPerustelu(
   val muuTutkintoTaiOpintosuoritus = perusteluMaybe
     .flatMap(_.uoRoSisalto.muuTutkinto)
     .map(sisalto => {
-      val label = translationService.getTranslation("fi", "perustelumuistio.uoro.muuTutkintoTaiSuoritus.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.uoro.muuTutkintoTaiSuoritus.label")
       s"$label\n$sisalto"
     })
 
@@ -598,20 +608,21 @@ def haeApPerustelu(translationService: TranslationService, perusteluMaybe: Optio
           .filter(_.==(true))
           .map(_ =>
             translationService
-              .getTranslation("fi", "perustelumuistio.ap.lakiperuste.toisessaJasenmaassaSaanneltyKoulutus")
+              .getTranslation(FI, "perustelumuistio.ap.lakiperuste.toisessaJasenmaassaSaanneltyKoulutus")
           ),
         apSisalto.lakiperustePatevyysLahtomaanOikeuksilla
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.ap.lakiperuste.lahtomaassaSaavutetutOikeudet")
+            translationService.getTranslation(FI, "perustelumuistio.ap.lakiperuste.lahtomaassaSaavutetutOikeudet")
           ),
         apSisalto.lakiperusteToinenEUmaaTunnustanut
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.ap.lakiperuste.toinenEUMaaTunnustanut")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.ap.lakiperuste.toinenEUMaaTunnustanut")),
         apSisalto.lakiperusteLahtomaassaSaantelematon
           .filter(_.==(true))
           .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.ap.lakiperuste.saantelematonAmmattiJaTyokokemus")
+            translationService
+              .getTranslation(FI, "perustelumuistio.ap.lakiperuste.saantelematonAmmattiJaTyokokemus")
           ),
 
         // ------- //
@@ -619,25 +630,26 @@ def haeApPerustelu(translationService: TranslationService, perusteluMaybe: Optio
           .filter(_.nonEmpty)
           .map(text =>
             val label =
-              translationService.getTranslation("fi", "perustelumuistio.ap.todistusEUKansalaisuusAsemasta.label")
+              translationService.getTranslation(FI, "perustelumuistio.ap.todistusEUKansalaisuusAsemasta.label")
             s"$label\n$text\n"
           ),
         apSisalto.ammattiJohonPatevoitynyt
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.ammattiJohonPatevoitynyt.label")
+            val label = translationService.getTranslation(FI, "perustelumuistio.ap.ammattiJohonPatevoitynyt.label")
             s"$label\n$text\n"
           ),
         apSisalto.ammattitoiminnanPaaAsiallinenSisalto
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.ammattitoiminnanSisalto.label")
+            val label = translationService.getTranslation(FI, "perustelumuistio.ap.ammattitoiminnanSisalto.label")
             s"$label\n$text\n"
           ),
         apSisalto.koulutuksenKestoJaSisalto
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.koulutuksenKestoJaSisalto.label")
+            val label =
+              translationService.getTranslation(FI, "perustelumuistio.ap.koulutuksenKestoJaSisalto.label")
             s"$label\n$text\n"
           ),
 
@@ -645,47 +657,46 @@ def haeApPerustelu(translationService: TranslationService, perusteluMaybe: Optio
         // Ammattipätevyyttä ja ammatin tai koulutuksen sääntelyä koskevat selvitykset
         apSisalto.selvityksetLahtomaanViranomaiselta
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.lahtomaanViranomaiselta")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.lahtomaanViranomaiselta")),
         apSisalto.selvityksetLahtomaanLainsaadannosta
           .filter(_.==(true))
-          .map(_ =>
-            translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.lahtomaanLainsaadannosta")
-          ),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.lahtomaanLainsaadannosta")),
         (apSisalto.selvityksetAikaisempiTapaus, apSisalto.selvityksetAikaisemmanTapauksenAsiaTunnus) match {
           case (Some(true), Some("")) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.aikaisempiTapaus"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.aikaisempiTapaus"))
           case (Some(true), None) =>
-            Some(translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.aikaisempiTapaus"))
+            Some(translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.aikaisempiTapaus"))
           case (Some(true), Some(asiatunnus)) => {
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.aikaisempiTapausLabel")
+            val label =
+              translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.aikaisempiTapausLabel")
             Some(s"$label $asiatunnus".trim)
           }
           case (_, _) => None
         },
         apSisalto.selvityksetIlmeneeAsiakirjoista
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.ap.selvitykset.asiakirjoista")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.ap.selvitykset.asiakirjoista")),
 
         // ------- //
         apSisalto.lisatietoja
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.lisatietoja.label")
+            val label = translationService.getTranslation(FI, "perustelumuistio.ap.lisatietoja.label")
             s"$label\n$text"
           ),
         apSisalto.IMIHalytysTarkastettu
           .filter(_.==(true))
-          .map(_ => translationService.getTranslation("fi", "perustelumuistio.ap.IMIHalytyksetTarkastettu")),
+          .map(_ => translationService.getTranslation(FI, "perustelumuistio.ap.IMIHalytyksetTarkastettu")),
         apSisalto.muutAPPerustelut
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.muutPerustelut.label")
+            val label = translationService.getTranslation(FI, "perustelumuistio.ap.muutPerustelut.label")
             s"$label\n$text"
           ),
         apSisalto.SEUTArviointi
           .filter(_.nonEmpty)
           .map(text =>
-            val label = translationService.getTranslation("fi", "perustelumuistio.ap.SEUTArviointi.label")
+            val label = translationService.getTranslation(FI, "perustelumuistio.ap.SEUTArviointi.label")
             s"$label\n$text"
           )
       ).flatten.mkString("\n")
@@ -712,12 +723,12 @@ def haeLausuntopyynnot(
           (pyynto.lausunnonAntajaKoodiUri, pyynto.lausunnonAntajaMuu) match {
             case (Some("muu"), Some(tarkenne)) => {
               val label =
-                translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.lausunnonAntaja.muuLabel")
+                translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.lausunnonAntaja.muuLabel")
               Some(s"$label $tarkenne".trim)
             }
             case (Some("muu"), None) =>
               Some(
-                translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.lausunnonAntaja.muu")
+                translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.lausunnonAntaja.muu")
               )
             case (Some(korkeakouluKoodi), _) =>
               val korkeakoulu = korkeakoulut
@@ -725,7 +736,7 @@ def haeLausuntopyynnot(
                 .flatMap(_.nimi.get(Kieli.fi))
 
               val label =
-                translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.lausunnonAntaja.label")
+                translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.lausunnonAntaja.label")
               korkeakoulu match {
                 case None                   => Some(s"$label $korkeakouluKoodi".trim)
                 case Some(korkeakoulunNimi) => Some(s"$label $korkeakoulunNimi".trim)
@@ -735,13 +746,13 @@ def haeLausuntopyynnot(
           pyynto.lahetetty
             .map(formatDate)
             .map(lahetetty => {
-              val label = translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.lahetetty.label")
+              val label = translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.lahetetty.label")
               s"$label $lahetetty".trim
             }),
           pyynto.saapunut
             .map(formatDate)
             .map(saapunut => {
-              val label = translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.saapunut.label")
+              val label = translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.saapunut.label")
               s"$label $saapunut".trim
             })
         ).flatten.mkString("\n")
@@ -749,7 +760,7 @@ def haeLausuntopyynnot(
 
       val sisalto = perustelu.lausunnonSisalto
         .map(sisalto => {
-          val label = translationService.getTranslation("fi", "perustelumuistio.lausuntopyynnot.sisalto.label")
+          val label = translationService.getTranslation(FI, "perustelumuistio.lausuntopyynnot.sisalto.label")
           s"$label\n$sisalto"
         })
 
@@ -777,7 +788,7 @@ def haeAsiakirjat(
     .flatMap(_.asiakirja)
     .flatMap(_.esittelijanHuomioita)
     .map(sisalto =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.asiakirjat.esittelijanHuomiot.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.asiakirjat.esittelijanHuomiot.label")
       s"$label\n$sisalto".trim
     )
 
@@ -801,7 +812,7 @@ def haeAsiakirjat(
 def haeSeutArviointiTehty(translationService: TranslationService, paatos: Paatos): Option[String] = {
   if (paatos.seutArviointi) {
     Some(
-      translationService.getTranslation("fi", "perustelumuistio.SEUTArviointi")
+      translationService.getTranslation(FI, "perustelumuistio.SEUTArviointi")
     )
   } else {
     None
@@ -812,15 +823,15 @@ def haeRatkaisutyyppi(translationService: TranslationService, paatos: Paatos): O
   paatos.ratkaisutyyppi
     .map {
       case Ratkaisutyyppi.Paatos =>
-        translationService.getTranslation("fi", "perustelumuistio.ratkaisutyyppi.paatos")
+        translationService.getTranslation(FI, "perustelumuistio.ratkaisutyyppi.paatos")
       case Ratkaisutyyppi.PeruutusTaiRaukeaminen =>
-        translationService.getTranslation("fi", "perustelumuistio.ratkaisutyyppi.peruutusTaiRaukeaminen")
+        translationService.getTranslation(FI, "perustelumuistio.ratkaisutyyppi.peruutusTaiRaukeaminen")
       case Ratkaisutyyppi.Oikaisu =>
-        translationService.getTranslation("fi", "perustelumuistio.ratkaisutyyppi.oikaisu")
+        translationService.getTranslation(FI, "perustelumuistio.ratkaisutyyppi.oikaisu")
       case Ratkaisutyyppi.JatetaanTutkimatta =>
-        translationService.getTranslation("fi", "perustelumuistio.ratkaisutyyppi.jatetaanTutkimatta")
+        translationService.getTranslation(FI, "perustelumuistio.ratkaisutyyppi.jatetaanTutkimatta")
       case Ratkaisutyyppi.Siirto =>
-        translationService.getTranslation("fi", "perustelumuistio.ratkaisutyyppi.siirto")
+        translationService.getTranslation(FI, "perustelumuistio.ratkaisutyyppi.siirto")
     }
 }
 
@@ -828,15 +839,15 @@ def haePaatosTyyppi(translationService: TranslationService, paatosTiedot: Paatos
   paatosTiedot.paatosTyyppi
     .map {
       case PaatosTyyppi.Taso =>
-        translationService.getTranslation("fi", "perustelumuistio.paatostyyppi.taso")
+        translationService.getTranslation(FI, "perustelumuistio.paatostyyppi.taso")
       case PaatosTyyppi.Kelpoisuus =>
-        translationService.getTranslation("fi", "perustelumuistio.paatostyyppi.kelpoisuus")
+        translationService.getTranslation(FI, "perustelumuistio.paatostyyppi.kelpoisuus")
       case PaatosTyyppi.TiettyTutkintoTaiOpinnot =>
-        translationService.getTranslation("fi", "perustelumuistio.paatostyyppi.tiettyTutkintoTaiOpinnot")
+        translationService.getTranslation(FI, "perustelumuistio.paatostyyppi.tiettyTutkintoTaiOpinnot")
       case PaatosTyyppi.RiittavatOpinnot =>
-        translationService.getTranslation("fi", "perustelumuistio.paatostyyppi.riittavatOpinnot")
+        translationService.getTranslation(FI, "perustelumuistio.paatostyyppi.riittavatOpinnot")
       case PaatosTyyppi.LopullinenPaatos =>
-        translationService.getTranslation("fi", "perustelumuistio.paatostyyppi.lopullinenPaatos")
+        translationService.getTranslation(FI, "perustelumuistio.paatostyyppi.lopullinenPaatos")
     }
 }
 
@@ -844,13 +855,13 @@ def haeSovellettuLaki(translationService: TranslationService, paatosTiedot: Paat
   paatosTiedot.sovellettuLaki
     .map {
       case SovellettuLaki.uo =>
-        translationService.getTranslation("fi", "perustelumuistio.sovellettuLaki.uo")
+        translationService.getTranslation(FI, "perustelumuistio.sovellettuLaki.uo")
       case SovellettuLaki.ap =>
-        translationService.getTranslation("fi", "perustelumuistio.sovellettuLaki.ap")
+        translationService.getTranslation(FI, "perustelumuistio.sovellettuLaki.ap")
       case SovellettuLaki.ap_seut =>
-        translationService.getTranslation("fi", "perustelumuistio.sovellettuLaki.apSeut")
+        translationService.getTranslation(FI, "perustelumuistio.sovellettuLaki.apSeut")
       case SovellettuLaki.ro =>
-        translationService.getTranslation("fi", "perustelumuistio.sovellettuLaki.ro")
+        translationService.getTranslation(FI, "perustelumuistio.sovellettuLaki.ro")
     }
 }
 
@@ -863,7 +874,7 @@ def haeTutkinnonNimi(
     .find(tutkinto => tutkinto.id == paatosTiedot.tutkintoId)
     .flatMap(_.nimi)
     .map(muotoiltu =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.tutkinnonNimi.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.tutkinnonNimi.label")
       s"$label $muotoiltu".trim
     )
 }
@@ -872,7 +883,7 @@ def haeMyonteinenTaiKielteinen(translationService: TranslationService, paatostie
   paatostiedot.myonteinenPaatos
     .map(toKyllaEi)
     .map(muotoiltu =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.myonteinenTaiKielteinen.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.myonteinenTaiKielteinen.label")
       s"$label $muotoiltu".trim
     )
 }
@@ -881,9 +892,9 @@ def haeTutkinnonTaso(translationService: TranslationService, paatostiedot: Paato
   paatostiedot.tutkintoTaso
     .map {
       case TutkintoTaso.AlempiKorkeakoulu =>
-        translationService.getTranslation("fi", "perustelumuistio.tutkinnonTaso.alempiKorkeakoulu")
+        translationService.getTranslation(FI, "perustelumuistio.tutkinnonTaso.alempiKorkeakoulu")
       case TutkintoTaso.YlempiKorkeakoulu =>
-        translationService.getTranslation("fi", "perustelumuistio.tutkinnonTaso.ylempiKorkeakoulu")
+        translationService.getTranslation(FI, "perustelumuistio.tutkinnonTaso.ylempiKorkeakoulu")
     }
 }
 
@@ -895,20 +906,20 @@ def haeKielteisenPaatosTiedonPerustelut(
     .map(_.epavirallinenKorkeakoulu)
     .filter(_ == true)
     .map(_ =>
-      translationService.getTranslation("fi", "perustelumuistio.kielteinenPaatos.perustelu.epavirallinenKorkeakoulu")
+      translationService.getTranslation(FI, "perustelumuistio.kielteinenPaatos.perustelu.epavirallinenKorkeakoulu")
     )
   val epavirallinenTutkinto = perustelut
     .map(_.epavirallinenTutkinto)
     .filter(_ == true)
     .map(_ =>
-      translationService.getTranslation("fi", "perustelumuistio.kielteinenPaatos.perustelu.epavirallinenTutkinto")
+      translationService.getTranslation(FI, "perustelumuistio.kielteinenPaatos.perustelu.epavirallinenTutkinto")
     )
   val eiVastaaSuomessaSuoritettavaaTutkintoa = perustelut
     .map(_.eiVastaaSuomessaSuoritettavaaTutkintoa)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.kielteinenPaatos.perustelu.eiVastaaTasoltaanSuomalaista")
+        .getTranslation(FI, "perustelumuistio.kielteinenPaatos.perustelu.eiVastaaTasoltaanSuomalaista")
     )
 
   val muuPerusteluSelected: Boolean = perustelut
@@ -919,7 +930,7 @@ def haeKielteisenPaatosTiedonPerustelut(
     perustelut
       .flatMap(_.muuPerusteluKuvaus)
       .map(kuvaus =>
-        val label = translationService.getTranslation("fi", "perustelumuistio.kielteinenPaatos.perustelu.muuLabel")
+        val label = translationService.getTranslation(FI, "perustelumuistio.kielteinenPaatos.perustelu.muuLabel")
         s"$label $kuvaus".trim
       )
   } else {
@@ -934,7 +945,7 @@ def haeKielteisenPaatosTiedonPerustelut(
   ).flatten
 
   if (result.nonEmpty) {
-    val label           = translationService.getTranslation("fi", "perustelumuistio.kielteinenPaatos.perustelu.label")
+    val label           = translationService.getTranslation(FI, "perustelumuistio.kielteinenPaatos.perustelu.label")
     val resultWithTitle = label +: result
     Some(resultWithTitle.mkString("\n"))
   } else {
@@ -948,59 +959,66 @@ def haePeruutusTaiRaukeaminen(translationService: TranslationService, paatos: Pa
   val eiSaaHakemaansaEikaHaluaPaatostaJonkaVoisiSaada = syyt
     .flatMap(_.eiSaaHakemaansaEikaHaluaPaatostaJonkaVoisiSaada)
     .filter(_ == true)
-    .map(_ => translationService.getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.eiSaaHakemaansa"))
+    .map(_ => translationService.getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.eiSaaHakemaansa"))
   val muutenTyytymatonRatkaisuun = syyt
     .flatMap(_.muutenTyytymatonRatkaisuun)
     .filter(_ == true)
     .map(_ =>
-      translationService.getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.muutenTyytymatonRatkaisuun")
+      translationService
+        .getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.muutenTyytymatonRatkaisuun")
     )
   val eiApMukainenTutkintoTaiHaettuaPatevyytta = syyt
     .flatMap(_.eiApMukainenTutkintoTaiHaettuaPatevyytta)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.eiAPLainMukainenTaiHaettuaAmmattipatevyytta")
+        .getTranslation(
+          FI,
+          "perustelumuistio.peruutusTaiRaukeaminen.syy.eiAPLainMukainenTaiHaettuaAmmattipatevyytta"
+        )
     )
   val eiTasoltaanVastaaSuomessaSuoritettavaaTutkintoa = syyt
     .flatMap(_.eiTasoltaanVastaaSuomessaSuoritettavaaTutkintoa)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.eiVastaaTasoltaanSuomalaista")
+        .getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.eiVastaaTasoltaanSuomalaista")
     )
   val epavirallinenKorkeakouluTaiTutkinto = syyt
     .flatMap(_.epavirallinenKorkeakouluTaiTutkinto)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.epavirallinenKorkeakouluTaiTutkinto")
+        .getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.epavirallinenKorkeakouluTaiTutkinto")
     )
   val eiEdellytyksiaRoEikaTasopaatokselle = syyt
     .flatMap(_.eiEdellytyksiaRoEikaTasopaatokselle)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.eiEdellytyksiaROTaiTasopaatokselle")
+        .getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.eiEdellytyksiaROTaiTasopaatokselle")
     )
   val eiEdellytyksiaRinnastaaTiettyihinKkOpintoihin = syyt
     .flatMap(_.eiEdellytyksiaRinnastaaTiettyihinKkOpintoihin)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.eiEdellytyksiaRinnastukselle")
+        .getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.eiEdellytyksiaRinnastukselle")
     )
   val hakijallaJoPaatosSamastaKoulutusKokonaisuudesta = syyt
     .flatMap(_.hakijallaJoPaatosSamastaKoulutusKokonaisuudesta)
     .filter(_ == true)
     .map(_ =>
       translationService
-        .getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.hakijallaOnJoPaatosKoulutuskokonaisuudesta")
+        .getTranslation(
+          FI,
+          "perustelumuistio.peruutusTaiRaukeaminen.syy.hakijallaOnJoPaatosKoulutuskokonaisuudesta"
+        )
     )
   val muuSyy = syyt
     .flatMap(_.muuSyy)
     .filter(_ == true)
-    .map(_ => translationService.getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.muu"))
+    .map(_ => translationService.getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.muu"))
 
   val result = Seq(
     eiSaaHakemaansaEikaHaluaPaatostaJonkaVoisiSaada,
@@ -1015,7 +1033,7 @@ def haePeruutusTaiRaukeaminen(translationService: TranslationService, paatos: Pa
   ).flatten
 
   if (result.nonEmpty) {
-    val label = translationService.getTranslation("fi", "perustelumuistio.peruutusTaiRaukeaminen.syy.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.peruutusTaiRaukeaminen.syy.label")
     Some((label +: result).mkString("\n"))
   } else {
     None
@@ -1055,7 +1073,7 @@ def haeRinnastettavatTutkinnotTaiOpinnot(
     })
 
   if (resultList.nonEmpty) {
-    val label = translationService.getTranslation("fi", "perustelumuistio.rinnastettavatTutkinnotTaiOpinnot.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.rinnastettavatTutkinnotTaiOpinnot.label")
     val resultWithTitle = label +: resultList
     Some(resultWithTitle.mkString("\n"))
   } else {
@@ -1089,7 +1107,7 @@ def haeKelpoisuudet(translationService: TranslationService, paatosTiedot: Paatos
   })
 
   if (resultList.nonEmpty) {
-    val label           = translationService.getTranslation("fi", "perustelumuistio.kelpoisuudet.label")
+    val label           = translationService.getTranslation(FI, "perustelumuistio.kelpoisuudet.label")
     val resultWithTitle = label +: resultList
     Some(resultWithTitle.mkString("\n"))
   } else {
@@ -1110,24 +1128,26 @@ def haeTutkinnonTaiOpinnonLisavaatimukset(
         if (lisavaatimukset.taydentavatOpinnot)
           Some(
             translationService
-              .getTranslation("fi", "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.taydentavatOpinnot")
+              .getTranslation(FI, "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.taydentavatOpinnot")
           )
         else None,
         if (lisavaatimukset.kelpoisuuskoe)
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.kelpoisuuskoe")
+            translationService
+              .getTranslation(FI, "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.kelpoisuuskoe")
           )
         else None,
         if (lisavaatimukset.sopeutumisaika)
           Some(
             translationService
-              .getTranslation("fi", "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.sopeutumisaika")
+              .getTranslation(FI, "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.sopeutumisaika")
           )
         else None
       ).flatten
 
       if (result.nonEmpty) {
-        val label = translationService.getTranslation("fi", "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.label")
+        val label =
+          translationService.getTranslation(FI, "perustelumuistio.tutkinnonTaiOpinnonLisavaatimukset.label")
         val resultWithTitle = label +: result
         Some(resultWithTitle.mkString("\n"))
       } else {
@@ -1144,7 +1164,7 @@ def haeKelpoisuudenLisavaatimukset(
     case None                  => None
     case Some(lisavaatimukset) =>
       val olennaisiaEroja = lisavaatimukset.olennaisiaEroja.map(_ =>
-        translationService.getTranslation("fi", "perustelumuistio.kelpoisuudenLisavaatimukset.olennaisiaEroja")
+        translationService.getTranslation(FI, "perustelumuistio.kelpoisuudenLisavaatimukset.olennaisiaEroja")
       )
 
       val erotKoulutuksessa = lisavaatimukset.erotKoulutuksessa
@@ -1156,7 +1176,7 @@ def haeKelpoisuudenLisavaatimukset(
             .filter(_ == true)
             .map(_ =>
               val label = translationService
-                .getTranslation("fi", "perustelumuistio.kelpoisuudenLisavaatimukset.erotKoulutuksessa.muuLabel")
+                .getTranslation(FI, "perustelumuistio.kelpoisuudenLisavaatimukset.erotKoulutuksessa.muuLabel")
               s"$label ${erotKoulutuksessa.muuEroKuvaus.getOrElse("")}".trim
             )
 
@@ -1164,7 +1184,7 @@ def haeKelpoisuudenLisavaatimukset(
 
           if (kaikkiErot.nonEmpty) {
             val label = translationService.getTranslation(
-              "fi",
+              FI,
               "perustelumuistio.kelpoisuudenLisavaatimukset.erotKoulutuksessa.label"
             )
             Some(
@@ -1190,7 +1210,7 @@ def haeKelpoisuudenLisavaatimukset(
             val ammattikokemus = kokemusJaOppiminen.ammattikokemus
               .map(_ =>
                 translationService.getTranslation(
-                  "fi",
+                  FI,
                   "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.ammattikokemus"
                 )
               )
@@ -1198,7 +1218,7 @@ def haeKelpoisuudenLisavaatimukset(
             val elinikainenOppiminen = kokemusJaOppiminen.elinikainenOppiminen
               .map(_ =>
                 translationService.getTranslation(
-                  "fi",
+                  FI,
                   "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.elinikainenOppiminen"
                 )
               )
@@ -1206,7 +1226,7 @@ def haeKelpoisuudenLisavaatimukset(
             val lisatieto = kokemusJaOppiminen.lisatieto
               .map(value =>
                 val label = translationService.getTranslation(
-                  "fi",
+                  FI,
                   "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.lisatietoLabel"
                 )
                 s"$label\n  $value".trim
@@ -1216,17 +1236,17 @@ def haeKelpoisuudenLisavaatimukset(
               .map {
                 case AmmattikokemusElinikainenOppiminenKorvaavuus.Taysi =>
                   translationService.getTranslation(
-                    "fi",
+                    FI,
                     "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.korvaavuus.taysin"
                   )
                 case AmmattikokemusElinikainenOppiminenKorvaavuus.Osittainen =>
                   translationService.getTranslation(
-                    "fi",
+                    FI,
                     "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.korvaavuus.osittain"
                   )
                 case AmmattikokemusElinikainenOppiminenKorvaavuus.Ei =>
                   translationService.getTranslation(
-                    "fi",
+                    FI,
                     "perustelumuistio.kelpoisuudenLisavaatimukset.ammattikokemusJaElinikainenOppiminen.korvaavuus.ei"
                   )
               }
@@ -1256,7 +1276,7 @@ def haeKelpoisuudenLisavaatimukset(
       ).flatten
 
       if (result.nonEmpty) {
-        val label = translationService.getTranslation("fi", "perustelumuistio.kelpoisuudenLisavaatimukset.label")
+        val label = translationService.getTranslation(FI, "perustelumuistio.kelpoisuudenLisavaatimukset.label")
         val resultWithTitle = label +: result
         Some(resultWithTitle.mkString("\n"))
       } else {
@@ -1292,7 +1312,7 @@ def haeKorvaavaToimenpide(
   ).flatten
 
   if (resultList.nonEmpty) {
-    val label = translationService.getTranslation("fi", "perustelumuistio.korvaavaToimenpide.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.korvaavaToimenpide.label")
     Some(
       (label +: resultList).mkString("\n")
     )
@@ -1311,23 +1331,23 @@ def haeKelpoisuuskoe(
       val result = Seq(
         if (sisalto.aihealue1)
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.kelpoisuuskoe.sisalto.aihealue1")
+            translationService.getTranslation(FI, "perustelumuistio.kelpoisuuskoe.sisalto.aihealue1")
           )
         else None,
         if (sisalto.aihealue2)
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.kelpoisuuskoe.sisalto.aihealue2")
+            translationService.getTranslation(FI, "perustelumuistio.kelpoisuuskoe.sisalto.aihealue2")
           )
         else None,
         if (sisalto.aihealue3)
           Some(
-            translationService.getTranslation("fi", "perustelumuistio.kelpoisuuskoe.sisalto.aihealue3")
+            translationService.getTranslation(FI, "perustelumuistio.kelpoisuuskoe.sisalto.aihealue3")
           )
         else None
       ).flatten
 
       if (result.nonEmpty) {
-        val label = translationService.getTranslation("fi", "perustelumuistio.kelpoisuuskoe.label")
+        val label = translationService.getTranslation(FI, "perustelumuistio.kelpoisuuskoe.label")
         Some(
           (label +: result).mkString("\n")
         )
@@ -1346,7 +1366,7 @@ def haeSopeutumisaika(
   kestoMaybe: Option[String]
 ): Option[String] = {
   if (valittu) {
-    val label = translationService.getTranslation("fi", "perustelumuistio.sopeutumisajanKesto.label")
+    val label = translationService.getTranslation(FI, "perustelumuistio.sopeutumisajanKesto.label")
     kestoMaybe.map(kesto => s"$label $kesto".trim)
   } else {
     None
@@ -1389,7 +1409,7 @@ def haePaatostiedot(
           }
         })
 
-      val label               = translationService.getTranslation("fi", "perustelumuistio.paatosEsitys.label")
+      val label               = translationService.getTranslation(FI, "perustelumuistio.paatosEsitys.label")
       val yleisetPaatostiedot = Seq(
         Some(label),
         ratkaisutyyppi
@@ -1438,7 +1458,7 @@ def haeEsittelija(
   onrService
     .haeNimiOption(hakemusMaybe.flatMap(_.esittelijaOid))
     .map(nimi =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.esittelija.label")
+      val label = translationService.getTranslation(FI, "perustelumuistio.esittelija.label")
       s"$label $nimi".trim
     )
 }
@@ -1467,13 +1487,15 @@ def haeKasittelyajat(translationService: TranslationService, hakemusMaybe: Optio
 
   val result = Seq(
     aikaKirjauksestaEsittelyynMonths.map(months =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.kasittelyajat.kirjauksestaEsittelyyn.label")
-      val unit  = translationService.getTranslation("fi", "perustelumuistio.kasittelyajat.yksikko.kuukautta")
+      val label =
+        translationService.getTranslation(FI, "perustelumuistio.kasittelyajat.kirjauksestaEsittelyyn.label")
+      val unit = translationService.getTranslation(FI, "perustelumuistio.kasittelyajat.yksikko.kuukautta")
       s"$label ${months} $unit"
     ),
     aikaAsiakirjastaPaatokseenMonths.map(months =>
-      val label = translationService.getTranslation("fi", "perustelumuistio.kasittelyajat.asiakirjastaRatkaisuun.label")
-      val unit  = translationService.getTranslation("fi", "perustelumuistio.kasittelyajat.yksikko.kuukautta")
+      val label =
+        translationService.getTranslation(FI, "perustelumuistio.kasittelyajat.asiakirjastaRatkaisuun.label")
+      val unit = translationService.getTranslation(FI, "perustelumuistio.kasittelyajat.yksikko.kuukautta")
       s"$label ${months} $unit"
     )
   ).flatten.mkString("\n")
@@ -1490,7 +1512,7 @@ def haePerusteluTitle(
   paatosMaybe: Option[Paatos]
 ): Option[String] = {
   // Esitetään Perustelu-otsikko vain jos ratkaisuehdotus on esitetty (paatosMaybe != None)
-  paatosMaybe.map(_ => translationService.getTranslation("fi", "perustelumuistio.perustelu.label"))
+  paatosMaybe.map(_ => translationService.getTranslation(FI, "perustelumuistio.perustelu.label"))
 }
 
 def generate(

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
@@ -912,7 +912,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
       .perform(get(s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti"))
       .andExpect(status().isOk)
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-      .andExpect(jsonPath("$.sisalto").value(startsWith("<p>Hakija:</p>")))
+      .andExpect(jsonPath("$.sisalto").value(startsWith("<p>")))
       .andExpect(jsonPath("$.muokkaaja").isEmpty)
       .andExpect(jsonPath("$.muokattu").isEmpty)
       .andExpect(jsonPath("$.vahvistettu").isEmpty)

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosServiceTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosServiceTest.scala
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.*
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 import org.mockito.{Mock, MockitoAnnotations}
+import fi.oph.tutu.backend.service.generator.paatosteksti.PaatosTekstiGenerator
 
 class PaatosServiceTest extends UnitTestBase {
 
@@ -35,6 +36,8 @@ class PaatosServiceTest extends UnitTestBase {
   var maakoodiService: MaakoodiService = _
   @Mock
   var onrService: OnrService = _
+  @Mock
+  var paatosTekstiGenerator: PaatosTekstiGenerator = _
 
   var paatosService: PaatosService = _
 
@@ -79,7 +82,8 @@ class PaatosServiceTest extends UnitTestBase {
       hallintoOikeusService = hallintoOikeusService,
       ataruLomakeParser = ataruLomakeParser,
       maakoodiService = maakoodiService,
-      onrService = onrService
+      onrService = onrService,
+      paatosTekstiGenerator = paatosTekstiGenerator
     )
   }
 

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
@@ -27,9 +27,21 @@ val paatostekstiTranslations = Map[String, String](
 
   "paatosteksti.tasoPaatosPerusteluBody" -> "<p>Opetushallitus on arvioinut hakijan tutkinnon{tutkintoNimi} vastaavan tasoltaan Suomessa suoritettavaa {koulu} korkeakoulututkintoa. Arvio perustuu siihen, että tutkintoon johtanut korkeakouluopintojen kokonaisuus vastaa laajuudeltaan, vaativuudeltaan ja suuntautumiseltaan {koulu}n korkeakoulututkintoon johtavaa korkeakouluopintojen kokonaisuutta.</p>",
 
-  "paatosteksti.tasoPaatosTutkinto" -> "<p>Hakijan suorittama korkeakoulututkinto{tutkintoNimi} rinnastetaan Suomessa suoritettavaan {koulu}n korkeakoulututkintoon.</p>",
+  "paatosteksti.tasoPaatos.myonteinen" -> "<p>Hakijan suorittama korkeakoulututkinto{tutkintoNimi} rinnastetaan Suomessa suoritettavaan {koulu}n korkeakoulututkintoon.</p>",
 
-  "paatosteksti.valitusoikeus" -> "<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla {hallintoOikeus}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>"
+  "paatosteksti.valitusoikeus" -> "<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla {hallintoOikeus}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>",
+
+  "paatosteksti.todistuksenPaivamaara"     -> "Todistuksen päivämäärä: {paivamaara}",
+  "paatosteksti.hakija"                    -> "Hakija:",
+  "paatosteksti.tasoPaatosPerusteluHeader" -> "<strong>Perustelu</strong>",
+  "paatosteksti.muuTutkinto"               -> "Muu tutkinto",
+
+  "paatosteksti.tasoPaatos.kielteinen" -> "<p>Hakijan suorittamaa tutkintoa ei rinnasteta Suomessa suoritettavaan korkeakoulututkintoon.</p>",
+
+  "paatosteksti.peruutus" -> "<strong>Päätös</strong><p>Hakija on peruuttanut hakemuksensa {peruutusPvm}. Hakemuksen käsittely raukeaa.</p>",
+
+  "paatosteksti.tutkinnonTaso.valitse" -> "<p>Valitse tutkinnon taso.</p>",
+  "paatosteksti.todo"                  -> "<p>Tällä hetkellä esikatselua ei ole saatavilla.</p>"
 )
 
 class PaatosTekstiGeneratorTest extends UnitTestBase {

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
@@ -3,7 +3,6 @@ package fi.oph.tutu.backend.service
 import fi.oph.tutu.backend.UnitTestBase
 import fi.oph.tutu.backend.domain.*
 import fi.oph.tutu.backend.fixture.*
-import fi.oph.tutu.backend.service.generator.paatosteksti.generatePaatosTeksti
 import org.junit.jupiter.api.Assertions.assertLinesMatch
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
@@ -13,11 +12,25 @@ import org.mockito.{Mock, MockitoAnnotations}
 import java.time.LocalDateTime
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
+import fi.oph.tutu.backend.service.generator.paatosteksti.PaatosTekstiGenerator
 
 class PaatosTekstiGeneratorTest extends UnitTestBase {
 
   @Mock
   var maakoodiService: MaakoodiService = _
+
+  @Mock
+  var translationService: TranslationService = _
+
+  var paatosTekstiGenerator: PaatosTekstiGenerator = _
+
+  @BeforeEach
+  def setup(): Unit = {
+    MockitoAnnotations.openMocks(this)
+    paatosTekstiGenerator = new PaatosTekstiGenerator(
+      translationService = translationService
+    )
+  }
 
   private val hakemusUUID = UUID.randomUUID()
   private val tutkintoId1 = UUID.randomUUID()
@@ -125,7 +138,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
       )
     )
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_paatos_taso.html"
     )
   }
@@ -154,11 +168,11 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
     )
 
     assertHtml(
-      generatePaatosTeksti(
+      this.paatosTekstiGenerator.generatePaatosTeksti(
         makeHakemus(),
         tutkinnot.filter(_.id == Some(tutkintoId1)), // Yksi tutkinto vain
         paatos,
-        "finnish",
+        Kieli.fi,
         hallintoOikeus,
         maakoodiService
       ),
@@ -177,7 +191,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
       )
     )
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_paatos_common.html"
     )
   }
@@ -193,7 +208,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
       )
     )
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_paatos_common.html"
     )
   }
@@ -209,7 +225,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
       )
     )
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_paatos_common.html"
     )
   }
@@ -221,11 +238,11 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
       peruutuksenTaiRaukeamisenSyy = Some(PeruutuksenTaiRaukeamisenSyy(muuSyy = Some(true)))
     )
     assertHtml(
-      generatePaatosTeksti(
+      this.paatosTekstiGenerator.generatePaatosTeksti(
         makeHakemus(peruutusPvm = Some(LocalDateTime.parse("2026-03-13T00:00:00"))),
         tutkinnot,
         paatos,
-        "finnish",
+        Kieli.fi,
         hallintoOikeus,
         maakoodiService
       ),
@@ -237,7 +254,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
   def oikaisuGeneroiTodoTekstin(): Unit = {
     val paatos = Paatos(ratkaisutyyppi = Some(Ratkaisutyyppi.Oikaisu))
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_todo.html"
     )
   }
@@ -246,7 +264,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
   def jatetaanTutkimattaGeneroiTodoTekstin(): Unit = {
     val paatos = Paatos(ratkaisutyyppi = Some(Ratkaisutyyppi.JatetaanTutkimatta))
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_todo.html"
     )
   }
@@ -255,7 +274,8 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
   def siirtoGeneroiTodoTekstin(): Unit = {
     val paatos = Paatos(ratkaisutyyppi = Some(Ratkaisutyyppi.Siirto))
     assertHtml(
-      generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, "finnish", hallintoOikeus, maakoodiService),
+      this.paatosTekstiGenerator
+        .generatePaatosTeksti(makeHakemus(), tutkinnot, paatos, Kieli.fi, hallintoOikeus, maakoodiService),
       "paatosteksti_todo.html"
     )
   }

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PaatosTekstiGeneratorTest.scala
@@ -13,6 +13,24 @@ import java.time.LocalDateTime
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 import fi.oph.tutu.backend.service.generator.paatosteksti.PaatosTekstiGenerator
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mockito.Mockito
+import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.cache.{Cache, CacheManager}
+
+val paatostekstiTranslations = Map[String, String](
+  "paatosteksti.maksunOikaisu" -> "<strong>Maksun oikaisu</strong><p>Päätöksestä perityt maksut perustuvat opetus- ja kulttuuriministeriön asetukseen Opetushallituksen ja sen erillisyksiköiden suoritteiden maksullisuudesta (1508/2025, 1 ja 2 §). Maksuihin voi vaatia oikaisua Opetushallitukselta. Liitteenä olevasta oikaisuvaatimusosoituksesta ilmenee oikaisuvaatimuksen määräaika ja se, miten oikaisua vaadittaessa on meneteltävä.</p><p>Käsittelymaksu 100 euroa</p>{paatosMaksu}",
+
+  "paatosteksti.maksunOikaisu.paatosMaksu" -> "<p>Päätösmaksu 395 euroa</p>",
+
+  "paatosteksti.tasoPaatosLaki" -> "<strong>Lainkohdat, joihin päätös perustuu</strong><p>Laki ulkomailla suoritettujen korkeakouluopintojen tuottamasta virkakelpoisuudesta (1385/2015), 2, 3 ja 6 §</p>",
+
+  "paatosteksti.tasoPaatosPerusteluBody" -> "<p>Opetushallitus on arvioinut hakijan tutkinnon{tutkintoNimi} vastaavan tasoltaan Suomessa suoritettavaa {koulu} korkeakoulututkintoa. Arvio perustuu siihen, että tutkintoon johtanut korkeakouluopintojen kokonaisuus vastaa laajuudeltaan, vaativuudeltaan ja suuntautumiseltaan {koulu}n korkeakoulututkintoon johtavaa korkeakouluopintojen kokonaisuutta.</p>",
+
+  "paatosteksti.tasoPaatosTutkinto" -> "<p>Hakijan suorittama korkeakoulututkinto{tutkintoNimi} rinnastetaan Suomessa suoritettavaan {koulu}n korkeakoulututkintoon.</p>",
+
+  "paatosteksti.valitusoikeus" -> "<strong>Valitusoikeus</strong><p>Tähän päätökseen saa hakea muutosta valittamalla {hallintoOikeus}. Liitteenä olevasta valitusosoituksesta ilmenee valituksen määräaika ja se, miten muutosta haettaessa on meneteltävä.</p>"
+)
 
 class PaatosTekstiGeneratorTest extends UnitTestBase {
 
@@ -20,17 +38,17 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
   var maakoodiService: MaakoodiService = _
 
   @Mock
+  var httpService: HttpService = _
+
+  @Mock
+  var mockCacheManager: CacheManager = _
+
+  @Mock
+  var mockCache: Cache = _
+
   var translationService: TranslationService = _
 
   var paatosTekstiGenerator: PaatosTekstiGenerator = _
-
-  @BeforeEach
-  def setup(): Unit = {
-    MockitoAnnotations.openMocks(this)
-    paatosTekstiGenerator = new PaatosTekstiGenerator(
-      translationService = translationService
-    )
-  }
 
   private val hakemusUUID = UUID.randomUUID()
   private val tutkintoId1 = UUID.randomUUID()
@@ -89,6 +107,28 @@ class PaatosTekstiGeneratorTest extends UnitTestBase {
   @BeforeEach
   def init(): Unit = {
     MockitoAnnotations.openMocks(this)
+
+    // Tyhjä cache
+    when(mockCacheManager.getCache("translations")).thenReturn(mockCache)
+    when(mockCache.get(any[String])).thenReturn(null)
+
+    // Käytetään spyta, jotta testataan oikealla koodilla parametrien korvausta
+    val realService = new TranslationService(httpService, new ObjectMapper())
+    ReflectionTestUtils.setField(realService, "cacheManager", mockCacheManager)
+    translationService = Mockito.spy(realService)
+
+    paatosTekstiGenerator = new PaatosTekstiGenerator(
+      translationService = translationService
+    )
+
+    Mockito
+      .doAnswer(i => {
+        val key = i.getArguments.apply(1).asInstanceOf[String]
+        paatostekstiTranslations.applyOrElse(key, key => key)
+      })
+      .when(translationService)
+      .getTranslation(any[Kieli], any[String])
+
     when(maakoodiService.getMaakoodiByUri(any[String])).thenReturn(
       Some(
         Maakoodi(

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PerusteluMuistioGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PerusteluMuistioGeneratorTest.scala
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.{Mock, MockitoAnnotations}
-import org.mockito.invocation.InvocationOnMock
 
 import java.time.LocalDateTime
 import java.util.UUID

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PerusteluMuistioGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/PerusteluMuistioGeneratorTest.scala
@@ -492,7 +492,7 @@ class PerusteluMuistioGeneratorTest extends UnitTestBase {
   def setup(): Unit = {
     MockitoAnnotations.openMocks(this)
     when(
-      translationService.getTranslation(any[String], any[String])
+      translationService.getTranslation(any[Kieli], any[String])
     ).thenAnswer(i => {
       val key = i.getArguments.apply(1).asInstanceOf[String]
       translations.applyOrElse(key, key => key)

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/TranslationServiceTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/TranslationServiceTest.scala
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.{Mock, MockitoAnnotations}
+import fi.oph.tutu.backend.domain.Kieli
 
 class TranslationServiceTest extends UnitTestBase {
   @Mock
@@ -32,14 +33,14 @@ class TranslationServiceTest extends UnitTestBase {
       }]
     """
     when(httpService.get(any[CasClient], any[String])).thenReturn(Right(responseString))
-    val translation = translationService.getTranslation("fi", "correct.key")
+    val translation = translationService.getTranslation(Kieli.fi, "correct.key")
     assertEquals(translation, "Success")
   }
 
   @Test
   def ReturnsTranslationKeyWhenTranslationIsNotFound(): Unit = {
     when(httpService.get(any[CasClient], any[String])).thenReturn(Left(Throwable("Key not found")))
-    val translation = translationService.getTranslation("fi", "incorrect.key")
+    val translation = translationService.getTranslation(Kieli.fi, "incorrect.key")
     assertEquals(translation, "incorrect.key")
   }
 }

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/ViestiServiceTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/ViestiServiceTest.scala
@@ -8,7 +8,6 @@ import fi.oph.tutu.backend.utils.Utility.toLocalDateTime
 
 import java.util.UUID
 import java.time.LocalDateTime
-import fi.oph.tutu.backend.domain.Kieli.fi
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.*
 import org.mockito.ArgumentMatchers.*
@@ -121,10 +120,10 @@ class ViestiServiceTest extends UnitTestBase {
 
   @Test
   def vahvistamisessaLisätäänAllekirjoitus(): Unit = {
-    val viesti = Viesti(kieli = Some(fi), viesti = Some("<p>alkuperäinen viesti</p>"))
-    when(translationService.getTranslation("fi", "hakemus.viesti.allekirjoitus.tervehdys"))
+    val viesti = Viesti(kieli = Some(Kieli.fi), viesti = Some("<p>alkuperäinen viesti</p>"))
+    when(translationService.getTranslation(Kieli.fi, "hakemus.viesti.allekirjoitus.tervehdys"))
       .thenReturn("Riehakasta perunannostolomaa")
-    when(translationService.getTranslation("fi", "hakemus.viesti.allekirjoitus.opetushallitus"))
+    when(translationService.getTranslation(Kieli.fi, "hakemus.viesti.allekirjoitus.opetushallitus"))
       .thenReturn("Opetushallitus")
     val vahvistettu = viestiService.taytaVahvistusTiedot(viesti, "1.2.246.562.24.00000000002")
     val sisalto     = vahvistettu.viesti.get


### PR DESCRIPTION
Viety päätösteksti käännöksiä suurimmalta osin tolgeeseen.
Cachetettu käännökset startupissa. Vaikka ei saataisi cachea ladattu, fallbackkaa http-pyyntöön. Päivittää kerran tunnissa jotta päivitykset tulevat käynnistämättäkin.