### PR TITLE
OPHTUTU-415: Muutoksia viestitoimintoihin

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/viesti/ViestiSisaltoGenerator.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/generator/viesti/ViestiSisaltoGenerator.scala
@@ -91,7 +91,7 @@ class ViestiSisaltoGenerator(translationService: TranslationService) extends Tut
       translationService.getTranslation(kieli, "hakemus.viesti.allekirjoitus.opetushallitus")
     val sahkopostiRivi =
       if (esittelija.sahkoposti.isDefined)
-        s"""|<br><a href="mailto:${esittelija.sahkoposti.get}"><span style="white-space: pre-wrap;">${esittelija.sahkoposti.get}</span></a>"""
+        s"""|<br><span style="white-space: pre-wrap;">${esittelija.sahkoposti.get}</span>"""
       else ""
     val puhnoRivi =
       if (esittelija.puhelinnumero.isDefined)

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/ViestiSisaltoGeneratorTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/ViestiSisaltoGeneratorTest.scala
@@ -26,32 +26,32 @@ class ViestiSisaltoGeneratorTest extends UnitTestBase {
     puhelinnumero = Some("123 456789")
   )
 
-  val timezone = ZoneId.of("Europe/Helsinki")
+  val timezone: ZoneId = ZoneId.of("Europe/Helsinki")
 
-  val otsikkoKaannokset = Seq[(String, String)](
+  val otsikkoKaannokset: Seq[(String, String)] = Seq[(String, String)](
     ("hakemus.viesti.taydennyspyynto.ylaOtsikko", "Pyyntö täydentää hakemusta"),
     ("hakemus.viesti.taydennyspyynto", "Täydennyspyyntö"),
     ("hakemus.viesti.taydennyspyynto.maaraaika.otsikko", "Määräaika"),
     ("hakemus.viesti.taydennyspyynto.kasittelyAika.otsikko", "Käsittelyaika")
   )
 
-  val allekirjoitusKaannokset = Seq[(String, String)](
+  val allekirjoitusKaannokset: Seq[(String, String)] = Seq[(String, String)](
     ("hakemus.viesti.allekirjoitus.opetushallitus", "Opetushallitus"),
     ("hakemus.viesti.allekirjoitus.tervehdys", "Riehakasta perunannostolomaa")
   )
 
-  val yleisetKaannokset = Seq[(String, String)](
+  val yleisetKaannokset: Seq[(String, String)] = Seq[(String, String)](
     ("hakemus.viesti.sisalto.tervehdys", "Howdy!!"),
     ("hakemus.viesti.sisalto.tietoaHakemuksesta", "Tää on hakemus"),
     ("hakemus.viesti.sisalto.lisatietoInfo", "Voit kysellä lisätietoa")
   )
 
-  val parametrisoidutKaannokset = Seq[(String, String)](
+  val parametrisoidutKaannokset: Seq[(String, String)] = Seq[(String, String)](
     ("hakemus.viesti.sisalto.maaraaika", "Määräaika: {date}"),
     ("hakemus.viesti.sisalto.asiatunnus", "Hakemuksesi Opetushallitukseen {asiatunnus}")
   )
 
-  val taydennyspyyntoKaannokset = Seq[(String, String)](
+  val taydennyspyyntoKaannokset: Seq[(String, String)] = Seq[(String, String)](
     ("hakemus.viesti.taydennyspyynto.yleisOhje", "Muutoksia täytyis tehdä"),
     ("hakemus.viesti.taydennyspyynto.tarkentavaOhje", "Ihan oikeasti"),
     ("hakemus.viesti.taydennyspyynto.maaraaika.yleisOhje", "Määräaika on tärkeä"),
@@ -60,8 +60,8 @@ class ViestiSisaltoGeneratorTest extends UnitTestBase {
     ("hakemus.viesti.taydennyspyynto.kasittelyAika.info", "Ihan oikeasti käsitellään joskus")
   )
 
-  val kaannoksetIlmanParametrilistaa  = otsikkoKaannokset ++ allekirjoitusKaannokset
-  val kaannoksetParametrilistanKanssa = yleisetKaannokset ++ taydennyspyyntoKaannokset
+  val kaannoksetIlmanParametrilistaa: Seq[(String, String)]  = otsikkoKaannokset ++ allekirjoitusKaannokset
+  val kaannoksetParametrilistanKanssa: Seq[(String, String)] = yleisetKaannokset ++ taydennyspyyntoKaannokset
   @BeforeEach
   def setup(): Unit = {
     MockitoAnnotations.openMocks(this)
@@ -89,7 +89,7 @@ class ViestiSisaltoGeneratorTest extends UnitTestBase {
     assert(sisalto.contains("Riehakasta perunannostolomaa,"))
     assert(sisalto.contains("Opetushallitus"))
     assert(sisalto.contains("Yrjö Kortesniemi"))
-    assert(sisalto.contains("mailto:yka@åbh.sv"))
+    assert(sisalto.contains("yka@åbh.sv"))
     assert(sisalto.contains("123 456789"))
   }
 
@@ -107,5 +107,6 @@ class ViestiSisaltoGeneratorTest extends UnitTestBase {
     kaikkiKaannokset.foreach { teksti =>
       assert(sisalto.contains(teksti), s"Tekstin '$teksti' pitäisi löytyä sisällöstä")
     }
+    assertAllekirjoitus(sisalto)
   }
 }

--- a/tutu-frontend/playwright/viesti.spec.ts
+++ b/tutu-frontend/playwright/viesti.spec.ts
@@ -41,7 +41,6 @@ const expectViestiFormToBeEmpty = async (page: Page) => {
   await expect(page.getByTestId('editor-content-editable')).toBeEmpty();
 
   await expect(page.getByTestId('viesti-tyhjenna-button')).toBeEnabled();
-  await expect(page.getByTestId('viesti-kopioi-button')).toBeDisabled();
   await expect(page.getByTestId('viesti-vahvista-button')).toBeDisabled();
 };
 
@@ -70,7 +69,6 @@ test('Olemassaoleva työversio ja vahvistettujen lista näkyvät oikein', async 
   await expect(page.getByTestId('editor-content-editable')).toHaveText(
     'Tämä on työversio',
   );
-  await expect(page.getByTestId('viesti-kopioi-button')).toBeEnabled();
   await expect(page.getByTestId('viesti-vahvista-button')).toBeEnabled();
 
   const viestiTable = page.getByTestId('vahvistettu-viesti-table');
@@ -188,7 +186,6 @@ test('Kenttien tyhjennyksessä tyhjennetään muut kentät paitsi kielivalinta',
   ).toBeChecked();
   await expect(otsikko).toHaveValue('Tämä on otsikko');
   await expect(sisalto).toHaveText('Tämä on varsinainen viesti');
-  await expect(page.getByTestId('viesti-kopioi-button')).toBeEnabled();
   await expect(page.getByTestId('viesti-vahvista-button')).toBeEnabled();
 
   await page.getByTestId('viesti-tyhjenna-button').click();
@@ -237,7 +234,6 @@ test('Tallennetun viestin tyhjennyksestä lähetetään PUT -kutsu backendille',
     page.getByTestId('viesti-otsikko-input').getByRole('textbox'),
   ).toBeEmpty();
   await expect(page.getByTestId('editor-content-editable')).toBeEmpty();
-  await expect(page.getByTestId('viesti-kopioi-button')).toBeDisabled();
   await expect(page.getByTestId('viesti-vahvista-button')).toBeDisabled();
   await expect(page.getByTestId('toast-alert')).toBeVisible();
   await expect(page.getByTestId('toast-alert')).toHaveAttribute(
@@ -262,7 +258,6 @@ test('Viestityypin oletussisältö latautuu automaattisesti', async ({
     page.locator('input[type="radio"][value="taydennyspyynto"]'),
   ).toBeChecked();
   await expect(sisalto).toHaveText('Oletussisältö');
-  await expect(page.getByTestId('viesti-kopioi-button')).toBeEnabled();
   await expect(page.getByTestId('viesti-vahvista-button')).toBeEnabled();
 });
 

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/components/Editor.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/components/Editor.tsx
@@ -85,15 +85,9 @@ const EditorInnerContainer = styled(Box)({
 const URL_REGEX =
   /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)(?<![-.+():%])/;
 
-const EMAIL_REGEX =
-  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-
 const MATCHERS = [
   createLinkMatcherWithRegExp(URL_REGEX, (text) => {
     return text.startsWith('http') ? text : `https://${text}`;
-  }),
-  createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => {
-    return `mailto:${text}`;
   }),
 ];
 

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DeleteOutline, CopyAll } from '@mui/icons-material';
+import { DeleteOutline } from '@mui/icons-material';
 import { useTheme } from '@mui/material';
 import { Stack } from '@mui/system';
 import {
@@ -25,13 +25,10 @@ import { FullSpinner } from '@/src/components/FullSpinner';
 import { SaveRibbon } from '@/src/components/SaveRibbon';
 import { useHakemus } from '@/src/context/HakemusContext';
 import { useEditableState } from '@/src/hooks/useEditableState';
-import useToaster, { AddToastCallback } from '@/src/hooks/useToaster';
+import useToaster from '@/src/hooks/useToaster';
 import { useUnsavedChanges } from '@/src/hooks/useUnsavedChanges';
 import { useViestiAll } from '@/src/hooks/useViestiAll';
-import {
-  TFunction,
-  useTranslations,
-} from '@/src/lib/localization/hooks/useTranslations';
+import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { Hakemus } from '@/src/lib/types/hakemus';
 import { Viesti, Viestityyppi } from '@/src/lib/types/viesti';
 import { handleFetchError, anyRealContentInHtml } from '@/src/lib/utils';
@@ -61,20 +58,6 @@ export default function ViestiPage() {
 
   return <ViestiPageComponent hakemus={hakemus} />;
 }
-
-const handleCopy = (
-  viesti: string,
-  addToast: AddToastCallback,
-  t: TFunction,
-) => {
-  navigator.clipboard.writeText(viesti);
-  addToast({
-    key: 'hakemus.viesti.kopioi.toaster',
-    message: t('hakemus.viesti.kopioituToast'),
-    type: 'success',
-    timeMs: 2500,
-  });
-};
 
 const ViestiPageComponent = ({ hakemus }: { hakemus: Hakemus }) => {
   const { t } = useTranslations();
@@ -251,48 +234,38 @@ const ViestiPageComponent = ({ hakemus }: { hakemus: Hakemus }) => {
         >
           {t(`hakemus.viesti.tyhjenna`)}
         </OphButton>
-        <Stack direction="row" gap={theme.spacing(1)}>
-          <OphButton
-            data-testid={`viesti-kopioi-button`}
-            disabled={editorEmpty}
-            variant="outlined"
-            startIcon={<CopyAll />}
-            onClick={() =>
-              handleCopy(exportMarkdown(editorRef.current), addToast, t)
-            }
-          >
-            {t(`hakemus.viesti.kopioi`)}
-          </OphButton>
-          <OphButton
-            data-testid={`viesti-vahvista-button`}
-            disabled={isViestiEmpty}
-            variant="contained"
-            onClick={() =>
-              showConfirmation({
-                header: t(`hakemus.viesti.vahvista.modal.otsikko`),
-                content: t(`hakemus.viesti.vahvista.modal.teksti`),
-                confirmButtonText: t(
-                  `hakemus.viesti.vahvista.modal.vahvistaViesti`,
-                ),
-                handleConfirmAction: () => {
-                  vahvistaViesti(viestiToBeSaved(), () => {
-                    paivitaVahvistettuLista();
-                  });
-                  if (viestiState.hasChanges) {
-                    // Vahvistettaessa viesti myös tallennetaan
-                    // Vahvistamisen jälkeen editoriin tuodaan uusi tallentamaton viesti,
-                    // joten discardataan mahdolliset muutokset
-                    viestiState.discard();
-                    setEditorHasChanges(false);
-                    setEditorEmpty(true);
-                  }
-                },
-              })
-            }
-          >
-            {t(`hakemus.viesti.vahvista`)}
-          </OphButton>
-        </Stack>
+        <OphButton
+          data-testid={`viesti-vahvista-button`}
+          disabled={isViestiEmpty}
+          variant="contained"
+          onClick={() =>
+            showConfirmation({
+              header: t(`hakemus.viesti.vahvista.modal.otsikko`),
+              content: t(`hakemus.viesti.vahvista.modal.teksti`),
+              confirmButtonText: t(
+                `hakemus.viesti.vahvista.modal.vahvistaViesti`,
+              ),
+              handleConfirmAction: () => {
+                navigator.clipboard.writeText(
+                  exportMarkdown(editorRef.current),
+                );
+                vahvistaViesti(viestiToBeSaved(), () => {
+                  paivitaVahvistettuLista();
+                });
+                if (viestiState.hasChanges) {
+                  // Vahvistettaessa viesti myös tallennetaan
+                  // Vahvistamisen jälkeen editoriin tuodaan uusi tallentamaton viesti,
+                  // joten discardataan mahdolliset muutokset
+                  viestiState.discard();
+                  setEditorHasChanges(false);
+                  setEditorEmpty(true);
+                }
+              },
+            })
+          }
+        >
+          {t(`hakemus.viesti.vahvistaJaKopioi`)}
+        </OphButton>
       </Stack>
       <VahvistettuList
         t={t}

--- a/tutu-frontend/src/hooks/useViestiAll.ts
+++ b/tutu-frontend/src/hooks/useViestiAll.ts
@@ -66,7 +66,10 @@ export const useViestiAll = (hakemusOid?: string) => {
     () =>
       [
         { when: viestiUpdateSuccess, value: 'hakemus.viesti.paivitetty' },
-        { when: vahvistusSuccess, value: 'hakemus.viesti.vahvistettu' },
+        {
+          when: vahvistusSuccess,
+          value: 'hakemus.viesti.vahvistettuJaKopioitu',
+        },
         { when: poistoSuccess, value: 'hakemus.viesti.poistettu' },
       ].find((item) => item.when)?.value || null,
     [poistoSuccess, vahvistusSuccess, viestiUpdateSuccess],


### PR DESCRIPTION
Poistettu viesteistä automaattiset email-linkit, jatkossa emailosoitteet näkyvät viesteissä normaalina tekstinä. 
Yhdistetty vahvista- ja kopio leikepöydälle -painikkeet, jatkossa viesti kopioidaan automaattisesti vahvistuksen yhteydessä.