### PR TITLE
Korjaa hakemushaku testi

### DIFF
--- a/tutu-frontend/playwright/hakemushaku.spec.ts
+++ b/tutu-frontend/playwright/hakemushaku.spec.ts
@@ -318,7 +318,6 @@ test('Aktiivinen välilehti säilyy palatessa alkuperäiseen hakemukseen', async
   await searchButtonClick(page);
 
   await expect(page.getByTestId('search-results-ribbon')).toBeVisible();
-  await page.getByText('Aalto, Aino').click();
 
   await expect(page.getByTestId('hakemusotsikko-hakija')).toHaveText(
     'Aalto, Aino',


### PR DESCRIPTION
Korjaa hakemushaku testi. Enää ei tarvitse klikata ensimmäistä hakutulosta, vaan se valitaan asynkronisesti niin testi ei aina toiminut.