### PR TITLE
OPHTUTU-451-461: Käyttöliittymä korjaukset

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusSearchRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusSearchRepository.scala
@@ -528,7 +528,8 @@ class HakemusSearchRepository extends BaseResultHandlers {
         filters.kelpoisuus.foreach(v => c += sql"k.kelpoisuus = $v")
         filters.opetettavatAineet.foreach(aineet => {
           val aineClauses = aineet
-            .map(aine => sql"k.opetettava_aine ILIKE ${s"%$aine%"}")
+            .map(aine => sql"""k.opetettava_aine ILIKE ${s"%$aine%"}
+                                OR tto.tutkinto_tai_opinto ILIKE ${s"%$aine%"}""")
             .reduce(_ ++ sql" OR " ++ _)
           c += sql"(" ++ aineClauses ++ sql")"
         })

--- a/tutu-frontend/src/app/(root)/components/FilemakerList.tsx
+++ b/tutu-frontend/src/app/(root)/components/FilemakerList.tsx
@@ -11,9 +11,8 @@ import {
   TableHead,
   TableRow,
 } from '@mui/material';
-import { ophColors } from '@opetushallitus/oph-design-system';
+import { ophColors, OphLink } from '@opetushallitus/oph-design-system';
 import { useQueryClient } from '@tanstack/react-query';
-import Link from 'next/link';
 import { parseAsInteger, useQueryState } from 'nuqs';
 import { useEffect } from 'react';
 
@@ -116,14 +115,14 @@ const HakemusRow = ({ hakemus }: { hakemus: any }) => {
   return (
     <TableRow data-testid={'filemaker-hakemus-row'}>
       <StyledTableCell>
-        <Link href={`/filemaker-hakemus/${hakemus.id}`}>
+        <OphLink href={`/filemaker-hakemus/${hakemus.id}`}>
           {kokonimi ? kokonimi : '-'}
-        </Link>
+        </OphLink>
       </StyledTableCell>
       <StyledTableCell>
-        <Link href={`/filemaker-hakemus/${hakemus.id}`}>
+        <OphLink href={`/filemaker-hakemus/${hakemus.id}`}>
           {asiatunnus ? asiatunnus : '-'}
-        </Link>
+        </OphLink>
       </StyledTableCell>
     </TableRow>
   );

--- a/tutu-frontend/src/app/(root)/components/HakemusListFilters.tsx
+++ b/tutu-frontend/src/app/(root)/components/HakemusListFilters.tsx
@@ -12,6 +12,7 @@ import {
   OphSelectMultiple,
   OphSelect,
   OphTypography,
+  ophColors,
 } from '@opetushallitus/oph-design-system';
 import { useQueryClient } from '@tanstack/react-query';
 import { redirect } from 'next/navigation';
@@ -113,12 +114,25 @@ export default function HakemusListFilters() {
 
   return (
     <Grid container spacing={theme.spacing(2)}>
-      <Grid container spacing={theme.spacing(2)} size={12}>
-        <Grid size={2}>
+      <Grid container spacing={theme.spacing(3)} size={12}>
+        <Grid size="auto">
           <OphFormFieldWrapper
+            sx={{
+              height: '64px',
+            }}
             renderInput={() => {
               return (
-                <ToggleButtonGroup>
+                <ToggleButtonGroup
+                  sx={{
+                    height: '100%',
+                    '& .MuiToggleButton-root': {
+                      fontWeight: 400,
+                      textWrapMode: 'nowrap',
+                      borderColor: ophColors.grey400,
+                      borderWidth: '1px',
+                    },
+                  }}
+                >
                   <ToggleButton
                     selected={!naytaKaikki}
                     value={'omat'}
@@ -154,7 +168,7 @@ export default function HakemusListFilters() {
             label={t('hakemuslista.nayta')}
           ></OphFormFieldWrapper>
         </Grid>
-        <Grid size={10}>
+        <Grid sx={{ flex: 1 }}>
           <OphInputFormField
             label={t('hakemuslista.haeHakemuksia')}
             sx={{ width: '100%' }}
@@ -167,7 +181,7 @@ export default function HakemusListFilters() {
           ></OphInputFormField>
         </Grid>
       </Grid>
-      <Grid container spacing={theme.spacing(2)} size={12}>
+      <Grid container spacing={theme.spacing(3)} size={12}>
         <Grid size={naytaKaikki ? 6 : 9}>
           <OphFormFieldWrapper
             label={t('hakemuslista.kasittelyvaihe')}

--- a/tutu-frontend/src/app/(root)/components/HakemusRow.tsx
+++ b/tutu-frontend/src/app/(root)/components/HakemusRow.tsx
@@ -3,10 +3,10 @@ import { Stack, TableRow } from '@mui/material';
 import {
   OphButton,
   OphInputFormField,
+  OphLink,
   OphTypography,
 } from '@opetushallitus/oph-design-system';
 import * as dateFns from 'date-fns';
-import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ApHakemusBadge, PeruutettuBadge } from '@/src/components/Badges';
@@ -103,9 +103,9 @@ export default function HakemusRow({
   return (
     <TableRow data-testid={'hakemus-row'}>
       <StyledTableCell>
-        <Link href={`/hakemus/${hakemus.hakemusOid}/perustiedot`}>
+        <OphLink href={`/hakemus/${hakemus.hakemusOid}/perustiedot`}>
           {hakemus.hakija.etunimet} {hakemus.hakija.sukunimi}
-        </Link>
+        </OphLink>
       </StyledTableCell>
       <StyledTableCell>
         <Stack

--- a/tutu-frontend/src/app/(root)/components/HakemusRow.tsx
+++ b/tutu-frontend/src/app/(root)/components/HakemusRow.tsx
@@ -143,7 +143,7 @@ export default function HakemusRow({
             <>
               <OphTypography>{asiatunnus}</OphTypography>
               <EditOutlined
-                sx={{ color: 'primary.main' }}
+                sx={{ color: 'primary.main', cursor: 'pointer' }}
                 onClick={() => setShowEditAsiatunnus(true)}
               ></EditOutlined>
             </>

--- a/tutu-frontend/src/app/(root)/components/MainPageLayout.tsx
+++ b/tutu-frontend/src/app/(root)/components/MainPageLayout.tsx
@@ -57,10 +57,18 @@ export default function MainPageLayout({
                 showNotification={hasNewMessages}
               />
               <Stack direction={'row'}>
-                <OphButton href="/tekstipohjat/viestipohjat" variant="text">
+                <OphButton
+                  href="/tekstipohjat/viestipohjat"
+                  variant="text"
+                  sx={{ fontWeight: 400 }}
+                >
                   {t('tekstipohjat.muokkausOtsikko')}
                 </OphButton>
-                <OphButton href="/maajako" variant="text">
+                <OphButton
+                  href="/maajako"
+                  variant="text"
+                  sx={{ fontWeight: 400 }}
+                >
                   {t('maajako.otsikko')}
                 </OphButton>
               </Stack>

--- a/tutu-frontend/src/app/(root)/components/MainPageLayout.tsx
+++ b/tutu-frontend/src/app/(root)/components/MainPageLayout.tsx
@@ -44,7 +44,7 @@ export default function MainPageLayout({
     >
       {hasTutuUserRights ? (
         <>
-          <BoxWrapper sx={{ borderBottom: 'none' }}>
+          <BoxWrapper sx={{ borderBottom: 'none', p: 0 }}>
             <Box
               sx={{
                 display: 'flex',

--- a/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
+++ b/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
@@ -4,7 +4,7 @@ import { OphButton, ophColors } from '@opetushallitus/oph-design-system';
 import { usePathname } from 'next/navigation';
 
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
-import { DEFAULT_BOX_BORDER, styled } from '@/src/lib/theme';
+import { styled } from '@/src/lib/theme';
 
 const TAB_BUTTON_HEIGHT = '48px';
 
@@ -116,7 +116,6 @@ export default function SivuValinta({
       direction="row"
       sx={{
         justifyContent: 'flex-start',
-        borderBottom: DEFAULT_BOX_BORDER,
         height: TAB_BUTTON_HEIGHT,
         p: 0,
         m: 0,

--- a/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
+++ b/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
@@ -21,7 +21,6 @@ const InactiveButton = styled(OphButton)({
   textDecoration: 'none',
   borderColor: 'transparent',
   backgroundColor: 'transparent',
-  transition: 'border-color 150ms, background-color 150ms',
   '&:hover': {
     borderColor: ophColors.blue2,
   },
@@ -32,17 +31,12 @@ const ActiveButton = styled(OphButton)({
   fontWeight: 'normal',
   height: TAB_BUTTON_HEIGHT,
   color: ophColors.white,
-  // ensure oph-design-system CSS variables used by OphButton keep text white
-  '--variant-containedColor': ophColors.white,
   textDecoration: 'none',
   borderColor: ophColors.blue2,
   backgroundColor: ophColors.blue2,
-  transition: 'background-color 150ms',
   '&:hover': {
     backgroundColor: ophColors.blue3,
-    // reinforce text color on hover (OphButton may override via CSS vars)
     color: ophColors.white,
-    '--variant-containedColor': ophColors.white,
   },
 });
 

--- a/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
+++ b/tutu-frontend/src/app/(root)/components/SivuValinta.tsx
@@ -1,6 +1,6 @@
 import ErrorIcon from '@mui/icons-material/Error';
-import { Box, Button, Stack } from '@mui/material';
-import { ophColors } from '@opetushallitus/oph-design-system';
+import { Stack } from '@mui/material';
+import { OphButton, ophColors } from '@opetushallitus/oph-design-system';
 import { usePathname } from 'next/navigation';
 
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
@@ -13,37 +13,51 @@ export enum SelectedPage {
   YhteinenKasittely,
 }
 
-const ActiveInfoIcon = styled(ErrorIcon)({
-  color: ophColors.orange3,
-  position: 'absolute',
-  left: '23.1%',
-});
-
-const InactiveInfoIcon = styled(ErrorIcon)({
-  color: ophColors.orange3,
-  position: 'absolute',
-  left: '94%',
-});
-
-const InactiveButton = styled(Button)({
+const InactiveButton = styled(OphButton)({
   borderRadius: 0,
   fontWeight: 'normal',
   height: TAB_BUTTON_HEIGHT,
-  color: 'black',
-  padding: '10px',
+  color: ophColors.blue2,
   textDecoration: 'none',
-  borderColor: ophColors.blue2,
+  borderColor: 'transparent',
+  backgroundColor: 'transparent',
+  transition: 'border-color 150ms, background-color 150ms',
+  '&:hover': {
+    borderColor: ophColors.blue2,
+  },
 });
 
-const ActiveButton = styled(Box)({
+const ActiveButton = styled(OphButton)({
   borderRadius: 0,
   fontWeight: 'normal',
   height: TAB_BUTTON_HEIGHT,
   color: ophColors.white,
-  padding: '10px',
+  // ensure oph-design-system CSS variables used by OphButton keep text white
+  '--variant-containedColor': ophColors.white,
   textDecoration: 'none',
   borderColor: ophColors.blue2,
   backgroundColor: ophColors.blue2,
+  transition: 'background-color 150ms',
+  '&:hover': {
+    backgroundColor: ophColors.blue3,
+    // reinforce text color on hover (OphButton may override via CSS vars)
+    color: ophColors.white,
+    '--variant-containedColor': ophColors.white,
+  },
+});
+
+const InfoBadge = styled(ErrorIcon)({
+  position: 'absolute',
+  left: '93%',
+  top: '5%',
+  width: 25,
+  height: 25,
+  color: `${ophColors.orange3} `,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  // This places a white circle right behind the transparent "!"
+  background: 'radial-gradient(circle, #ffffff 40%, transparent 40%)',
 });
 
 const useActiveHakuTabName = () => {
@@ -72,19 +86,17 @@ const TabButton = ({
 
   const isActive = active || activeTabName === tabName;
 
-  const InfoIcon = isActive ? ActiveInfoIcon : InactiveInfoIcon;
-
   return (
     <>
       {isActive ? (
         <ActiveButton {...rest}>
           {t(tabName)}
-          {showNotification && <InfoIcon />}
+          {showNotification && <InfoBadge />}
         </ActiveButton>
       ) : (
         <InactiveButton href={linkPath || ''}>
           {t(tabName)}
-          {showNotification && <InfoIcon />}
+          {showNotification && <InfoBadge />}
         </InactiveButton>
       )}
     </>
@@ -106,6 +118,8 @@ export default function SivuValinta({
         justifyContent: 'flex-start',
         borderBottom: DEFAULT_BOX_BORDER,
         height: TAB_BUTTON_HEIGHT,
+        p: 0,
+        m: 0,
       }}
     >
       <TabButton

--- a/tutu-frontend/src/app/(root)/components/TableHeaderCell/index.tsx
+++ b/tutu-frontend/src/app/(root)/components/TableHeaderCell/index.tsx
@@ -53,7 +53,10 @@ export const TableHeaderCell = memo(function TableHeaderCell({
   const { orderBy, direction } = getSortParts(sort, colId);
 
   return (
-    <StyledHeaderCell sx={style} sortDirection={direction}>
+    <StyledHeaderCell
+      sx={{ padding: '8px 10px', ...style }}
+      sortDirection={direction}
+    >
       {setSort && sortable ? (
         <Button
           sx={{

--- a/tutu-frontend/src/app/(root)/components/Tabs.tsx
+++ b/tutu-frontend/src/app/(root)/components/Tabs.tsx
@@ -7,23 +7,27 @@ import { usePathname } from 'next/navigation';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { DEFAULT_BOX_BORDER, styled } from '@/src/lib/theme';
 
-const TAB_BUTTON_HEIGHT = '48px';
+const TAB_BUTTON_HEIGHT = '32px';
 
 const InactiveButton = styled(OphButton)({
   borderRadius: 0,
   fontWeight: 'normal',
   height: TAB_BUTTON_HEIGHT,
   color: 'black',
+  padding: '4px 8px',
+  marginRight: '10px',
 });
 
 const ActiveButton = styled(OphButton)({
   borderRadius: 0,
-  fontWeight: 'bold',
+  fontWeight: 'normal',
   height: TAB_BUTTON_HEIGHT,
   borderColor: ophColors.blue2,
   borderWidth: 0,
   borderBottomWidth: 2,
   cursor: 'default',
+  padding: '4px 8px',
+  marginRight: '10px',
 });
 
 const useActiveHakuTabName = () => {

--- a/tutu-frontend/src/app/(root)/components/Tabs.tsx
+++ b/tutu-frontend/src/app/(root)/components/Tabs.tsx
@@ -96,6 +96,7 @@ const Tabs = ({ buttons, tPrefix }: TabsParams) => {
         width: '100%',
         borderBottom: DEFAULT_BOX_BORDER,
         height: TAB_BUTTON_HEIGHT,
+        marginBottom: '16px',
       }}
       aria-label={t(`${tPrefix}.tabs`)}
     >

--- a/tutu-frontend/src/app/(root)/yhteinenKasittely/page.tsx
+++ b/tutu-frontend/src/app/(root)/yhteinenKasittely/page.tsx
@@ -36,7 +36,7 @@ export default function YkPage() {
     >
       {hasTutuUserRights ? (
         <>
-          <BoxWrapper sx={{ borderBottom: 'none' }}>
+          <BoxWrapper sx={{ borderBottom: 'none', p: 0 }}>
             <Box
               sx={{
                 display: 'flex',

--- a/tutu-frontend/src/app/(root)/yhteinenKasittely/page.tsx
+++ b/tutu-frontend/src/app/(root)/yhteinenKasittely/page.tsx
@@ -2,7 +2,6 @@
 
 import { Box } from '@mui/material';
 import { OphButton, OphTypography } from '@opetushallitus/oph-design-system';
-import Link from 'next/link';
 
 import SivuValinta, {
   SelectedPage,
@@ -48,9 +47,13 @@ export default function YkPage() {
                 active={SelectedPage.YhteinenKasittely}
                 showNotification={hasMessages}
               />
-              <Link href="/maajako" style={{ textDecoration: 'none' }}>
-                <OphButton variant="text">{t('maajako.otsikko')}</OphButton>
-              </Link>
+              <OphButton
+                href="/maajako"
+                variant="text"
+                sx={{ fontWeight: 400 }}
+              >
+                {t('maajako.otsikko')}
+              </OphButton>
             </Box>
           </BoxWrapper>
           <YkMainPage />

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/DirektiivitasoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/DirektiivitasoComponent.tsx
@@ -1,7 +1,7 @@
-import { OphSelectFormField } from '@opetushallitus/oph-design-system';
 import React from 'react';
 
 import { direktiivitasoOptions } from '@/src/app/hakemus/[oid]/paatostiedot/constants';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import { Direktiivitaso } from '@/src/lib/types/paatos';
 
@@ -16,7 +16,7 @@ export type DirektiivitasoProps = {
 export const DirektiivitasoComponent = (props: DirektiivitasoProps) => {
   const { t, label, direktiivitaso, updateDirektiivitaso, dataTestId } = props;
   return (
-    <OphSelectFormField
+    <OphSelectFormFieldPatched
       placeholder={t('yleiset.valitse')}
       label={label}
       sx={{ width: '100%' }}

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/EhdollinenPaatosComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/EhdollinenPaatosComponent.tsx
@@ -1,17 +1,14 @@
 import { Add } from '@mui/icons-material';
 import { Divider } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import {
-  OphButton,
-  OphCheckbox,
-  OphSelectFormField,
-} from '@opetushallitus/oph-design-system';
+import { OphButton, OphCheckbox } from '@opetushallitus/oph-design-system';
 import React, { useEffect } from 'react';
 
 import { PaatosTietoList } from '@/src/app/hakemus/[oid]/paatostiedot/components/PaatosTietoList';
 import { PeruutuksenTaiRaukeamisenSyyComponent } from '@/src/app/hakemus/[oid]/paatostiedot/components/PeruutuksenTaiRaukeamisenSyyComponent';
 import { ratkaisutyyppiOptions } from '@/src/app/hakemus/[oid]/paatostiedot/constants';
 import { emptyPaatosTieto } from '@/src/app/hakemus/[oid]/paatostiedot/paatostietoUtils';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import { Paatos, PaatosTieto, Ratkaisutyyppi } from '@/src/lib/types/paatos';
 import { Tutkinto } from '@/src/lib/types/tutkinto';
@@ -103,7 +100,7 @@ export const EhdollinenPaatosComponent = ({
         }}
         data-testid={'paatos-seut'}
       />
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder={t('yleiset.valitse')}
         label={t('hakemus.paatos.ratkaisutyyppi.otsikko')}
         data-testid={'paatos-ratkaisutyyppi'}

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/LopullinenPaatosComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/LopullinenPaatosComponent.tsx
@@ -1,5 +1,4 @@
 import { Theme } from '@mui/material/styles';
-import { OphSelectFormField } from '@opetushallitus/oph-design-system';
 import React from 'react';
 
 import { KorvaavatToimenpiteet } from '@/src/app/hakemus/[oid]/paatostiedot/components/KorvaavatToimenpiteet';
@@ -9,6 +8,7 @@ import {
   emptyPaatosTieto,
   korvaavaToimenpide2Paatostiedot,
 } from '@/src/app/hakemus/[oid]/paatostiedot/paatostietoUtils';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import {
   KorvaavaToimenpideDto,
@@ -56,7 +56,7 @@ export const LopullinenPaatosComponent = ({
           updatePaatosField(toBePaatos);
         }}
       />
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder={t('yleiset.valitse')}
         label={t('hakemus.paatos.ratkaisutyyppi.otsikko')}
         data-testid={'paatos-ratkaisutyyppi'}

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/PaatosTietoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/PaatosTietoComponent.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { Stack } from '@mui/material';
-import {
-  OphCheckbox,
-  OphSelectFormField,
-} from '@opetushallitus/oph-design-system';
+import { OphCheckbox } from '@opetushallitus/oph-design-system';
 import React, { useEffect, useState } from 'react';
 
 import { KelpoisuusList } from '@/src/app/hakemus/[oid]/paatostiedot/components/kelpoisuus/KelpoisuusList';
@@ -16,6 +13,7 @@ import {
   tutkinnonTasoOptions,
   tutkintoOptions,
 } from '@/src/app/hakemus/[oid]/paatostiedot/constants';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import {
   PaatosTieto,
@@ -97,7 +95,7 @@ export const PaatosTietoComponent = ({
 
   return (
     <Stack direction={'column'} gap={2}>
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder={t('yleiset.valitse')}
         label={t('hakemus.paatos.paatostyyppi.otsikko')}
         options={paatostyyppiOptions(t)}
@@ -117,7 +115,7 @@ export const PaatosTietoComponent = ({
         (currentPaatosTieto.paatosTyyppi === 'Kelpoisuus' ||
           currentPaatosTieto.paatosTyyppi === 'Taso') && (
           <>
-            <OphSelectFormField
+            <OphSelectFormFieldPatched
               placeholder={t('yleiset.valitse')}
               label={t('hakemus.paatos.tutkinto.nimi')}
               options={tutkintoOptions(t, tutkinnot)}
@@ -166,7 +164,7 @@ export const PaatosTietoComponent = ({
                   t={t}
                 />
                 {currentPaatosTieto.myonteinenPaatos && (
-                  <OphSelectFormField
+                  <OphSelectFormFieldPatched
                     placeholder={t('yleiset.valitse')}
                     label={t('hakemus.paatos.tutkinto.tutkinnonTaso')}
                     options={tutkinnonTasoOptions(t)}

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/SovellettuLakiComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/SovellettuLakiComponent.tsx
@@ -1,7 +1,7 @@
-import { OphSelectFormField } from '@opetushallitus/oph-design-system';
 import React from 'react';
 
 import { sovellettuLakiOptions } from '@/src/app/hakemus/[oid]/paatostiedot/constants';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import { PaatosTieto, Paatostyyppi } from '@/src/lib/types/paatos';
 
@@ -17,7 +17,7 @@ export const SovellettuLakiComponent = ({
   handleChange,
 }: SovellettuLakiComponentProps) => {
   return (
-    <OphSelectFormField
+    <OphSelectFormFieldPatched
       placeholder={t('yleiset.valitse')}
       label={t('hakemus.paatos.sovellettuLaki.otsikko')}
       options={sovellettuLakiOptions(

--- a/tutu-frontend/src/app/hakemus/[oid]/perustiedot/components/LopullisenHakemuksenSisalto.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/perustiedot/components/LopullisenHakemuksenSisalto.tsx
@@ -1,12 +1,10 @@
 import { Divider, Stack } from '@mui/material';
 import { Theme } from '@mui/material/styles';
-import {
-  OphInputFormField,
-  OphSelectFormField,
-} from '@opetushallitus/oph-design-system';
+import { OphInputFormField } from '@opetushallitus/oph-design-system';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { Sisalto } from '@/src/app/hakemus/[oid]/perustiedot/components/Sisalto';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { lopullinenPaatosSuoritukset } from '@/src/constants/hakemuspalveluSisalto';
 import { useKoodistoOptions } from '@/src/hooks/useKoodistoOptions';
 import {
@@ -73,7 +71,7 @@ export const LopullisenHakemuksenSisalto = ({
           'data-testid': `vastaavaEhdollinenPaatos-input`,
         }}
       />
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder={t('yleiset.valitse')}
         label={t('hakemus.perustiedot.lopullinenPaatos.suoritusmaa')}
         sx={{ width: '50%' }}

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/TutkintoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/TutkintoComponent.tsx
@@ -5,12 +5,12 @@ import { Divider, Stack, Box } from '@mui/material';
 import {
   OphButton,
   OphInputFormField,
-  OphSelectFormField,
   OphTypography,
 } from '@opetushallitus/oph-design-system';
 import React from 'react';
 
 import { useGlobalConfirmationModal } from '@/src/components/ConfirmationModal';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { useHakemus } from '@/src/context/HakemusContext';
 import { TFunction } from '@/src/lib/localization/hooks/useTranslations';
 import { OphSelectOption } from '@/src/lib/types/common';
@@ -129,7 +129,7 @@ export const TutkintoComponent = ({
           </OphButton>
         )}
       </Stack>
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder={t('yleiset.valitse')}
         label={t('hakemus.tutkinnot.tutkinto.tutkintoTodistusOtsikko')}
         options={resolveTutkintoTodistusOtsikkoOptions()}
@@ -226,7 +226,7 @@ export const TutkintoComponent = ({
         </Box>
       </Stack>
       <Stack direction="column" gap={0.5}>
-        <OphSelectFormField
+        <OphSelectFormFieldPatched
           placeholder={t('yleiset.valitse')}
           label={t('hakemus.tutkinnot.tutkinto.tutkinnonMaa')}
           sx={{ width: '50%' }}
@@ -306,7 +306,7 @@ export const TutkintoComponent = ({
         }}
       />
       {tutkinto.jarjestys === '1' && (
-        <OphSelectFormField
+        <OphSelectFormFieldPatched
           placeholder={t('yleiset.valitse')}
           label={t('hakemus.tutkinnot.tutkinto.tutkinnonKoulutusala')}
           sx={{ width: '25%' }}

--- a/tutu-frontend/src/app/hakemus/[oid]/yhteinenkasittely/components/KasittelyModal.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/yhteinenkasittely/components/KasittelyModal.tsx
@@ -3,11 +3,11 @@ import {
   OphTypography,
   OphInputFormField,
   OphButton,
-  OphSelectFormField,
   ophColors,
 } from '@opetushallitus/oph-design-system';
 import React from 'react';
 
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { Esittelija } from '@/src/lib/types/esittelija';
 import { YhteinenKasittely } from '@/src/lib/types/yhteinenkasittely';
@@ -70,7 +70,7 @@ export const UusiKasittelyModal: React.FC<UusiKasittelyModalProps> = ({
           >
             {t('hakemus.yhteinenkasittely.uusiKasittely.body')}
           </OphTypography>
-          <OphSelectFormField
+          <OphSelectFormFieldPatched
             label={t('hakemus.yhteinenkasittely.uusiKasittely.tyopari')}
             placeholder={t('yleiset.valitse')}
             onChange={(e) => setTyopari(e.target.value)}
@@ -159,7 +159,7 @@ export const JatkoKasittelyModal: React.FC<JatkoKasittelyModalProps> = ({
           >
             {t('hakemus.yhteinenkasittely.jatkoKasittely.body')}
           </OphTypography>
-          <OphSelectFormField
+          <OphSelectFormFieldPatched
             label={t('hakemus.yhteinenkasittely.uusiKasittely.tyopari')}
             placeholder={t('yleiset.valitse')}
             onChange={(e) => setTyopari(e.target.value)}

--- a/tutu-frontend/src/app/maajako/components/EsittelijaSection.tsx
+++ b/tutu-frontend/src/app/maajako/components/EsittelijaSection.tsx
@@ -1,10 +1,8 @@
 import { Box, Chip } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
-import {
-  OphSelectFormField,
-  OphTypography,
-} from '@opetushallitus/oph-design-system';
+import { OphTypography } from '@opetushallitus/oph-design-system';
 
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { Esittelija } from '@/src/lib/types/esittelija';
 
 import { TFunction } from '../../../lib/localization/hooks/useTranslations';
@@ -107,7 +105,7 @@ export const EditEsittelijaSection = ({
       <OphTypography variant={'h4'}>
         {esittelija.etunimi} {esittelija.sukunimi}
       </OphTypography>
-      <OphSelectFormField
+      <OphSelectFormFieldPatched
         placeholder="yleiset.valitse"
         label={t('maajako.tutkinnonsuoritusmaat')}
         multiple
@@ -135,7 +133,7 @@ export const EditEsittelijaSection = ({
                 ))}
           </Box>
         )}
-      ></OphSelectFormField>
+      />
     </>
   );
 };

--- a/tutu-frontend/src/app/maajako/page.tsx
+++ b/tutu-frontend/src/app/maajako/page.tsx
@@ -2,11 +2,7 @@
 
 import { Divider, Stack, useTheme } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
-import {
-  OphButton,
-  OphSelectFormField,
-  OphTypography,
-} from '@opetushallitus/oph-design-system';
+import { OphButton, OphTypography } from '@opetushallitus/oph-design-system';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import {
@@ -17,6 +13,7 @@ import { SelectedMaakoodiInfo } from '@/src/app/maajako/components/SelectedMaako
 import { AlertBox } from '@/src/components/AlertBox';
 import { BoxWrapper } from '@/src/components/BoxWrapper';
 import { FullSpinner } from '@/src/components/FullSpinner';
+import { OphSelectFormFieldPatched } from '@/src/components/OphSelectFormFieldPatched';
 import { SaveRibbon } from '@/src/components/SaveRibbon';
 import { SuccessBox } from '@/src/components/SuccessBox';
 import { useEsittelijat } from '@/src/hooks/useEsittelijat';
@@ -161,7 +158,7 @@ export default function MaajakoPage() {
           <OphTypography variant={'h3'}>
             {t('maajako.kenellevalittu')}
           </OphTypography>
-          <OphSelectFormField
+          <OphSelectFormFieldPatched
             placeholder={t('yleiset.valitse')}
             label={t('maajako.suoritusmaa')}
             sx={{ width: '50%', marginBottom: theme.spacing(1) }}
@@ -171,7 +168,7 @@ export default function MaajakoPage() {
               setSelectedMaakoodi(event.target.value)
             }
             data-testid={'suoritusmaa'}
-          ></OphSelectFormField>
+          />
 
           <SelectedMaakoodiInfo
             maakoodit={sortedMaakoodit}

--- a/tutu-frontend/src/components/HakemusHeader.tsx
+++ b/tutu-frontend/src/components/HakemusHeader.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { Divider, SelectChangeEvent, Stack, useTheme } from '@mui/material';
-import {
-  OphSelectFormField,
-  OphTypography,
-} from '@opetushallitus/oph-design-system';
+import { OphTypography } from '@opetushallitus/oph-design-system';
 
 import { DATE_PLACEHOLDER } from '@/src/constants/constants';
 import { useHakemus } from '@/src/context/HakemusContext';
@@ -14,6 +11,7 @@ import { useKasittelyvaiheTranslation } from '@/src/lib/localization/hooks/useKa
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 
 import { PeruutettuBadge } from './Badges';
+import { OphSelectFormFieldPatched } from './OphSelectFormFieldPatched';
 
 export const HakemusHeader = () => {
   const {
@@ -76,7 +74,7 @@ export const HakemusHeader = () => {
             }}
           >
             {t('hakemusotsikko.esittelija')}{' '}
-            <OphSelectFormField
+            <OphSelectFormFieldPatched
               placeholder={t('yleiset.valitse')}
               options={esittelijaOptions}
               value={

--- a/tutu-frontend/src/components/OphSelectFormFieldPatched.tsx
+++ b/tutu-frontend/src/components/OphSelectFormFieldPatched.tsx
@@ -1,0 +1,98 @@
+import MenuItem from '@mui/material/MenuItem/MenuItem';
+import Select, { SelectProps } from '@mui/material/Select/Select';
+import {
+  ophColors,
+  OphFormFieldWrapper,
+} from '@opetushallitus/oph-design-system';
+
+import { OphSelectOption } from '../lib/types/common';
+
+interface OphFormFieldWrapperCommonProps {
+  /**
+   * If true, the label will indicate that the input is required.
+   */
+  required?: boolean;
+  /**
+   * The label text show above the input
+   */
+  label?: string;
+  /**
+   * The helper text shown below the input
+   */
+  helperText?: string;
+  /**
+   * An error message shown after the input. If defined also sets the field and label in error state (red).
+   */
+  errorMessage?: string;
+}
+
+interface OphSelectProps<T> extends Omit<
+  SelectProps<T>,
+  | 'children'
+  | 'label'
+  | 'variant'
+  | 'components'
+  | 'componentsProps'
+  | 'disableUnderline'
+> {
+  /**
+   * Selectable options for the select component.
+   */
+  options: Array<OphSelectOption<T>>;
+  /**
+   * Can the value be cleared from the select component.
+   */
+  clearable?: boolean;
+  /**
+   * Placeholder text shown when no value is selected.
+   */
+  placeholder?: string;
+}
+
+type OphSelectFormFieldProps<T> = OphFormFieldWrapperCommonProps &
+  OphSelectProps<T>;
+
+// OphSelectFormField but with grey placeholder
+export const OphSelectFormFieldPatched = <T extends string>({
+  required,
+  label,
+  helperText,
+  errorMessage,
+  sx,
+  ...props
+}: OphSelectFormFieldProps<T | ''>) => {
+  return (
+    <OphFormFieldWrapper
+      sx={sx}
+      required={required}
+      label={label}
+      helperText={helperText}
+      disabled={props.disabled}
+      errorMessage={errorMessage}
+      renderInput={({ labelId }) => <OphSelect {...props} labelId={labelId} />}
+    />
+  );
+};
+
+const OphSelect = <T extends string>({
+  placeholder,
+  clearable,
+  options,
+  ...props
+}: OphSelectProps<T | ''>) => {
+  return (
+    <Select defaultValue="" displayEmpty {...props} label={null}>
+      <MenuItem sx={{ display: clearable ? 'block' : 'none' }} value="">
+        {/*Patched grey placeholder*/}
+        <span style={{ color: ophColors.grey500 }}>{placeholder}</span>
+      </MenuItem>
+      {options.map(({ value, label }) => {
+        return (
+          <MenuItem value={value} key={value}>
+            {label}
+          </MenuItem>
+        );
+      })}
+    </Select>
+  );
+};

--- a/tutu-frontend/src/components/PageLayout.tsx
+++ b/tutu-frontend/src/components/PageLayout.tsx
@@ -37,7 +37,7 @@ export const PageLayout = ({
         width: '100%',
         alignItems: 'stretch',
       }}
-      gap={theme.spacing(2)}
+      gap={theme.spacing(4)}
     >
       <HeaderWrapper>
         <PageContent>{header}</PageContent>

--- a/tutu-frontend/src/components/StyledTableCell.tsx
+++ b/tutu-frontend/src/components/StyledTableCell.tsx
@@ -2,4 +2,7 @@ import { styled, TableCell } from '@mui/material';
 
 export const StyledTableCell = styled(TableCell)({
   borderBottom: 'none',
+  padding: '8px 10px',
+  height: '40px',
+  boxSizing: 'content-box',
 });

--- a/tutu-frontend/src/components/sidebar/KasittelyVaihe.tsx
+++ b/tutu-frontend/src/components/sidebar/KasittelyVaihe.tsx
@@ -1,11 +1,7 @@
 'use client';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Stack, styled, useTheme } from '@mui/material';
-import {
-  ophColors,
-  OphSelectFormField,
-  OphTypography,
-} from '@opetushallitus/oph-design-system';
+import { ophColors, OphTypography } from '@opetushallitus/oph-design-system';
 import React from 'react';
 import * as R from 'remeda';
 
@@ -15,6 +11,8 @@ import { StyledLink } from '@/src/components/StyledLink';
 import { useHakemus } from '@/src/context/HakemusContext';
 import { useKasittelyvaiheTranslation } from '@/src/lib/localization/hooks/useKasittelyvaiheTranslation';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
+
+import { OphSelectFormFieldPatched } from '../OphSelectFormFieldPatched';
 
 const OpenInNewIconBlue = styled(OpenInNewIcon)({
   color: ophColors.blue2,
@@ -42,14 +40,14 @@ export const KasittelyVaihe = ({ showExtended }: { showExtended: boolean }) => {
           {t('hakemus.sivupalkki.kasittelyvaihe')}
         </OphTypography>
         {showExtended ? (
-          <OphSelectFormField
+          <OphSelectFormFieldPatched
             placeholder={t('yleiset.valitse')}
             options={R.map(kasittelyVaiheet, (vaihe) => ({
               label: t(`hakemus.kasittelyvaihe.${vaihe.toLowerCase()}`),
               value: vaihe,
             }))}
             defaultValue={kasittelyVaiheet[0]}
-          ></OphSelectFormField>
+          />
         ) : (
           <OphTypography
             variant={'body1'}

--- a/tutu-frontend/src/constants/opetettavaAineFilterOptions.ts
+++ b/tutu-frontend/src/constants/opetettavaAineFilterOptions.ts
@@ -10,8 +10,8 @@ import {
 
 const opetettavaAineItems: TranslationNode[] = [
   {
-    tKey: 'haku.opetettavatAineet.opetusalanAmmatit',
-    value: 'Opetusalan ammatit',
+    tKey: 'haku.opetettavatAineet.opetettavatAineet',
+    value: 'Opetettavat aineet',
     children: [
       {
         tKey: 'haku.opetettavatAineet.aidinkieliJaKirjallisuus',
@@ -150,19 +150,46 @@ const opetettavaAineItems: TranslationNode[] = [
       },
     ],
   },
+  // Yhdistetty tiettyTutkintoTaiOpinnotOptions
   {
-    tKey: 'haku.opetettavatAineet.varhaiskasvatuksenTehtavat',
-    value: 'Varhaiskasvatuksen tehtävät',
-    children: [
-      {
-        tKey: 'haku.opetettavatAineet.paivakodinJohtaja',
-        value: 'Päiväkodin johtaja',
-      },
-      {
-        tKey: 'haku.opetettavatAineet.steinerpedagoginenHenkilosto',
-        value: 'Steinerpedagogisen henkilöstön tehtävät',
-      },
-    ],
+    tKey: 'haku.opetettavatAineet.paivakodinJohtaja',
+    value: 'Päiväkodin johtaja',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.steinerpedagoginenHenkilosto',
+    value: 'Steinerpedagogisen henkilöstön tehtävät',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.rinnastaminenOikeustieteenMaisterinTutkintoon',
+    value: 'Rinnastaminen oikeustieteen maisterin tutkintoon',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.opettajanPedagogisetOpinnot',
+    value: 'Opettajan pedagogiset opinnot',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.erityisopetuksenTehtaviinAmmatillisiaValmiuksiaAntavatOpinnot',
+    value: 'Erityisopetuksen tehtäviin ammatillisia valmiuksia antavat opinnot',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.oppilaanohjauksenJaOpintoOhjauksenTehtaviinAmmatillisiaValmiuksiaAntavatOpinnot',
+    value:
+      'Oppilaanohjauksen ja opinto-ohjauksen tehtäviin ammatillisia valmiuksia antavat opinnot',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.kasvatustieteellisenAlanKorkeakoulututkinto',
+    value:
+      'Kasvatustieteellisen alan korkeakoulututkinto (kasvatustieteen kandidaatti, kasvatustieteen maisteri, kasvatustieteen lisensiaatti tai kasvatustieteen tohtori)',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.sosiaaliJaTerveysalanAmmattikorkeakoulututkinto',
+    value:
+      'Sosiaali- ja terveysalan ammattikorkeakoulututkinto tai ylempi ammattikorkeakoulututkinto (sosionomi (AMK) tai sosionomi (ylempi AMK))',
+  },
+  {
+    tKey: 'haku.opetettavatAineet.muuOpetustehtavaTaiVarhaiskasvatuksenOpintosuoritus',
+    value:
+      'Muu opetustehtävään tai varhaiskasvatuksen tehtävään vaadittava korkeakoulun opintosuoritus',
   },
 ];
 

--- a/tutu-frontend/src/lib/types/common.ts
+++ b/tutu-frontend/src/lib/types/common.ts
@@ -10,7 +10,7 @@ export type NamedBoolean = {
   value: boolean;
 };
 
-export type OphSelectOption = {
-  label: string;
-  value: string;
+export type OphSelectOption<T = string> = {
+  label: T;
+  value: T;
 };


### PR DESCRIPTION
OPHTUTU-461: Korjaa placeholder OphSelectFormFieldPatched
OPHTUTU-457 & OPHTUTU-458
OPHTUTU-460 - Kälikorjaukset: Taulukon solujen korkeus
OPHTUTU-456 - Kälikorjaukset: Esittelijöiden maajako-linkki Kehityksessä
OPHTUTU-455 - Kälikorjaukset: Välilehtien ja hakukriteerien väli
OPHTUTU-454 - Kälikorjaukset: Välilehtien taitto
OPHTUTU-452: Korjaa ylävalikkojen taitto
OPHTUTU-451: Korjaa listaus linkki tyylit