### PR TITLE
OPHTUTU-427: Perustelumuistion tallennus -- repository ja servicen päivityskutsu

### DIFF
--- a/tutu-backend/src/main/resources/db/migration/V202606031030000__create_perustelumuistio_table.sql
+++ b/tutu-backend/src/main/resources/db/migration/V202606031030000__create_perustelumuistio_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS perustelumuistio (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hakemus_id UUID UNIQUE NOT NULL,
+    sisalto TEXT NOT NULL,
+    luotu TIMESTAMPTZ DEFAULT now(),
+    luoja VARCHAR(255) NOT NULL,
+    muokattu TIMESTAMPTZ,
+    muokkaaja VARCHAR(255),
+    CONSTRAINT fk_perustelumuistio_hakemus FOREIGN KEY (hakemus_id) REFERENCES hakemus (id)
+);
+
+CREATE OR REPLACE TRIGGER trg_perustelumuistio_update_muokattu_timestamp
+    BEFORE UPDATE ON perustelumuistio
+    FOR EACH ROW
+    EXECUTE FUNCTION update_muokattu_timestamp();
+
+COMMENT ON TABLE perustelumuistio IS 'Perustelumuistio';
+COMMENT ON COLUMN perustelumuistio.id IS 'Taulun rivin id';
+COMMENT ON COLUMN perustelumuistio.hakemus_id IS 'Hakemustaulun hakemuksen id';
+COMMENT ON COLUMN perustelumuistio.sisalto IS 'Perustelumuistion tekstisisältö';
+COMMENT ON COLUMN perustelumuistio.luotu IS 'Taulun rivin luontiaika';
+COMMENT ON COLUMN perustelumuistio.luoja IS 'Taulun rivin luoja';
+COMMENT ON COLUMN perustelumuistio.muokattu IS 'Taulun rivin viimeisin muokkausaika';
+COMMENT ON COLUMN perustelumuistio.muokkaaja IS 'Taulun rivin viimeisin muokkaaja';

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/TutuBackendApplication.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/TutuBackendApplication.scala
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.{ApplicationArguments, ApplicationRunner, SpringApplication}
 import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableAsync
 
 object TutuBackendApplication {
   val CALLER_ID = "1.2.246.562.10.00000000001.tutu-virkailija"
@@ -14,6 +15,7 @@ object TutuBackendApplication {
 }
 
 @SpringBootApplication
+@EnableAsync
 @EnableConfigurationProperties
 class TutuBackendApplication {
 

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/PerusteluController.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/PerusteluController.scala
@@ -2,7 +2,7 @@ package fi.oph.tutu.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.oph.tutu.backend.domain.{HakemusOid, Perustelu}
-import fi.oph.tutu.backend.service.{PerusteluService, UserService}
+import fi.oph.tutu.backend.service.{PerusteluServiceInterface, UserService}
 import fi.oph.tutu.backend.utils.AuditOperation.{ReadPerustelu, UpdatePerustelu}
 import fi.oph.tutu.backend.utils.{AuditLog, AuditUtil, ErrorMessageMapper}
 import io.swagger.v3.oas.annotations.Operation
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
 @RestController
 @RequestMapping(path = Array("api"))
 class PerusteluController(
-  perusteluService: PerusteluService,
+  perusteluService: PerusteluServiceInterface,
   userService: UserService,
   mapper: ObjectMapper,
   val auditLog: AuditLog

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Perustelu.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Perustelu.scala
@@ -128,3 +128,13 @@ case class APSisalto(
   muutAPPerustelut: Option[String] = None,
   SEUTArviointi: Option[String] = None
 )
+
+case class Perustelumuistio(
+  id: UUID,
+  hakemusId: UUID,
+  sisalto: String,
+  luotu: LocalDateTime,
+  luoja: String,
+  muokattu: Option[LocalDateTime] = None,
+  muokkaaja: Option[String] = None
+)

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/HakemusRepository.scala
@@ -328,4 +328,17 @@ class HakemusRepository extends BaseResultHandlers {
           e
         )
     }
+
+  def hakemusIdToOid(hakemusId: UUID): Option[HakemusOid] = {
+    try {
+      db.run(
+        sql"""
+          SELECT hakemus_oid FROM hakemus WHERE  id = ${hakemusId.toString}::uuid
+        """.as[HakemusOid].headOption,
+        "hakemus_id_to_oid"
+      )
+    } catch {
+      case e: Exception => None
+    }
+  }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PerusteluRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PerusteluRepository.scala
@@ -66,6 +66,20 @@ class PerusteluRepository extends BaseResultHandlers {
     )
   }
 
+  implicit val getPerustelumuistioResult: GetResult[Perustelumuistio] = {
+    GetResult(r =>
+      Perustelumuistio(
+        id = UUID.fromString(r.nextString()),
+        hakemusId = UUID.fromString(r.nextString()),
+        sisalto = r.nextString(),
+        luotu = r.nextTimestamp().toLocalDateTime,
+        luoja = r.nextString(),
+        muokattu = r.nextTimestampOption().map(_.toLocalDateTime),
+        muokkaaja = r.nextStringOption()
+      )
+    )
+  }
+
   /**
    * Tallentaa uuden perustelun (palauttaa DBIO-actionin transaktioita varten)
    *
@@ -365,4 +379,100 @@ class PerusteluRepository extends BaseResultHandlers {
       DELETE FROM lausuntopyynto
       WHERE id = ${id.toString}::uuid
     """
+
+  def haePerustelumuistio(hakemusOid: HakemusOid): Option[Perustelumuistio] = {
+    try {
+      db.run(
+        sql"""
+          SELECT
+            id,
+            hakemus_id,
+            sisalto,
+            luotu,
+            luoja,
+            muokattu,
+            muokkaaja
+          FROM
+            perustelumuistio
+          WHERE hakemus_id IN
+            (SELECT id FROM hakemus where hakemus_oid = ${hakemusOid.toString})
+        """.as[Perustelumuistio].headOption,
+        "hae_perustelu"
+      )
+    } catch {
+      case e: Exception =>
+        LOG.error(s"Perustelumuistion haku epäonnistui (hakemusOid: ${hakemusOid.toString}): $e")
+        throw new RuntimeException(
+          s"Perustelumuistion haku epäonnistui (hakemusOid: ${hakemusOid.toString}): ${e.getMessage}",
+          e
+        )
+    }
+  }
+
+  def lisaaPerustelumuistio(
+    hakemusOid: HakemusOid,
+    sisalto: String,
+    luoja: String
+  ): Perustelumuistio = {
+    try {
+      db.run(
+        sql"""
+          INSERT INTO perustelumuistio (
+            hakemus_id
+            sisalto
+            luoja
+          )
+          VALUES (
+            SELECT id FROM hakemus WHERE hakemus_oid = ${hakemusOid.toString},
+            $sisalto,
+            $luoja
+          )
+          RETURNING
+            id,
+            hakemus_id,
+            sisalto,
+            luotu,
+            luoja,
+            muokattu,
+            muokkaaja
+        """.as[Perustelumuistio].head,
+        "lisaa_perustelumuistio"
+      )
+    } catch {
+      case e: Exception =>
+        LOG.error(s"Virhe perustelumuistion lisäämisessä: ${e.getMessage}", e)
+        throw new RuntimeException(s"Virhe perustelumuistion lisäämisessä: ${e.getMessage}", e)
+    }
+  }
+
+  def paivitaPerustelumuistio(
+    hakemusOid: HakemusOid,
+    sisalto: String,
+    muokkaaja: String
+  ): Perustelumuistio = {
+    try {
+      db.run(
+        sql"""
+          UPDATE perustelumuistio
+          SET
+            sisalto = $sisalto,
+            muokkaaja = $muokkaaja
+          WHERE hakemus_id IN (SELECT id FROM hakemus WHERE hakemus_oid = ${hakemusOid.toString})
+          RETURNING
+            id,
+            hakemus_id,
+            sisalto,
+            luotu,
+            luoja,
+            muokattu,
+            muokkaaja
+        """.as[Perustelumuistio].head,
+        "paivita_perustelumuistio"
+      )
+    } catch {
+      case e: Exception =>
+        LOG.error(s"Virhe perustelumuistion päivittämisessä: ${e.getMessage}", e)
+        throw new RuntimeException(s"Virhe perustelumuistion päivittämisessä: ${e.getMessage}", e)
+    }
+  }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/HakemusService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/HakemusService.scala
@@ -596,4 +596,8 @@ class HakemusService(
         LOG.warn(s"Vastaanotettiin päivitys hakemukselle ${hakemusOid.s} jota ei löydy TUTU -kannasta")
     }
   }
+
+  def hakemusIdToOid(hakemusId: UUID): Option[HakemusOid] = {
+    hakemusRepository.hakemusIdToOid(hakemusId)
+  }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
@@ -11,6 +11,28 @@ import java.time.LocalDateTime
 import java.util.UUID
 import org.springframework.scheduling.annotation.Async
 
+trait PerusteluServiceInterface {
+  def haePerustelu(
+    hakemusOid: HakemusOid
+  ): Option[Perustelu]
+  def tallennaPerustelu(
+    hakemusOid: HakemusOid,
+    perustelu: Perustelu,
+    luojaTaiMuokkaaja: String
+  ): (Option[Perustelu], Option[Perustelu])
+  def haePerusteluMuistio(
+    hakemusOid: HakemusOid
+  ): Option[String]
+  def paivitaPerustelumuistio(
+    hakemusOid: HakemusOid,
+    muokkaaja: String
+  ): Unit
+  def paivitaPerustelumuistio(
+    hakemusId: UUID,
+    muokkaaja: String
+  ): Unit
+}
+
 @Component
 @Service
 class PerusteluService(
@@ -26,7 +48,8 @@ class PerusteluService(
   koodistoService: KoodistoService,
   onrService: OnrService,
   translationService: TranslationService
-) extends TutuJsonFormats {
+) extends TutuJsonFormats
+    with PerusteluServiceInterface {
   val LOG: Logger = LoggerFactory.getLogger(classOf[PerusteluService])
 
   def haePerustelu(

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
@@ -155,4 +155,11 @@ class PerusteluService(
       }
     })
   }
+
+  def paivitaPerustelumuistio(
+    hakemusId: UUID,
+    muokkaaja: String
+  ): Unit = {
+    hakemusService.hakemusIdToOid(hakemusId).map(hakemusOid => paivitaPerustelumuistio(hakemusOid, muokkaaja))
+  }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
@@ -9,6 +9,7 @@ import org.springframework.stereotype.{Component, Service}
 
 import java.time.LocalDateTime
 import java.util.UUID
+import org.springframework.scheduling.annotation.Async
 
 @Component
 @Service
@@ -144,6 +145,7 @@ class PerusteluService(
     Some(perusteluMuistio)
   }
 
+  @Async
   def paivitaPerustelumuistio(
     hakemusOid: HakemusOid,
     muokkaaja: String

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
@@ -143,4 +143,16 @@ class PerusteluService(
 
     Some(perusteluMuistio)
   }
+
+  def paivitaPerustelumuistio(
+    hakemusOid: HakemusOid,
+    muokkaaja: String
+  ): Unit = {
+    haePerusteluMuistio(hakemusOid).map(sisalto => {
+      perusteluRepository.haePerustelumuistio(hakemusOid) match {
+        case None    => perusteluRepository.lisaaPerustelumuistio(hakemusOid, sisalto, muokkaaja)
+        case Some(_) => perusteluRepository.paivitaPerustelumuistio(hakemusOid, sisalto, muokkaaja)
+      }
+    })
+  }
 }


### PR DESCRIPTION
## Perustelumuistion tallennus osa 1: tietokantatason tallennusmekanismi

PR sisältää tietokantatason tallennusmekanismin, jota ei vielä ole kytketty muihin järjestelmän osiin.

Seuraavissa PR:ssä kytketään `perusteluService`:een lisätty funktio muihin serviceihin siten, että muutokset hakemuksen tietoihin laukaisee perustelumuistion päivityksen.