### PR TITLE
OPHTUTU-378: Logiikkamuutoksia vahvistetun päätöstekstin muokkaamiseen

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
@@ -633,7 +633,8 @@ class PaatosRepository extends BaseResultHandlers {
     sql"""UPDATE paatosteksti
         SET
           sisalto = ${paatosteksti.sisalto},
-          muokkaaja = $muokkaaja
+          muokkaaja = $muokkaaja,
+          vahvistettu = null
         WHERE id = ${paatostekstiId.toString}::uuid
         RETURNING
           id,

--- a/tutu-frontend/playwright/editori.paatos.spec.ts
+++ b/tutu-frontend/playwright/editori.paatos.spec.ts
@@ -54,14 +54,19 @@ test('Päätöstekstin vahvistamisesta lähetetään PUT -kutsu backendille', as
 }) => {
   const saveButton = page.getByTestId('save-ribbon-button');
   await expect(saveButton).toBeHidden();
+  const vahvistettuAikaleima = page.getByTestId('vahvistettu-aikaleima');
+  const vahvistaButton = page.getByTestId('vahvista-kopioi-painike');
+  await expect(vahvistaButton).toHaveText(
+    await translate(page, 'hakemus.editori.paatos.vahvista'),
+  );
+
+  await expect(vahvistettuAikaleima).toBeHidden();
 
   await page
     .getByTestId('editor-content-editable')
     .fill('Muokattu vahvistettava päätösteksti');
 
-  await page
-    .getByText(await translate(page, 'hakemus.editori.paatos.vahvista'))
-    .click();
+  await vahvistaButton.click();
 
   const [request] = await Promise.all([
     page.waitForRequest(
@@ -76,6 +81,40 @@ test('Päätöstekstin vahvistamisesta lähetetään PUT -kutsu backendille', as
     sisalto:
       '<p><span style="white-space: pre-wrap;">Muokattu vahvistettava päätösteksti</span></p>',
   });
+
+  await expect(vahvistettuAikaleima).toBeVisible();
+  await expect(vahvistaButton).toHaveText(
+    await translate(page, 'hakemus.editori.paatos.kopioi'),
+  );
+});
+
+test('Vahvistetun päätöstekstin tallennus palauttaa tekstin vahvistamattomaksi', async ({
+  page,
+}) => {
+  const saveButton = page.getByTestId('save-ribbon-button');
+  const editori = page.getByTestId('editor-content-editable');
+  await expect(saveButton).toBeHidden();
+  const vahvistettuAikaleima = page.getByTestId('vahvistettu-aikaleima');
+  const vahvistaButton = page.getByTestId('vahvista-kopioi-painike');
+  await expect(vahvistaButton).toHaveText(
+    await translate(page, 'hakemus.editori.paatos.vahvista'),
+  );
+  await expect(vahvistettuAikaleima).toBeHidden();
+
+  await editori.fill('Vahvistettava päätösteksti');
+  await vahvistaButton.click();
+  await page.getByTestId('modal-confirm-button').click();
+  await expect(vahvistettuAikaleima).toBeVisible();
+  await expect(vahvistaButton).toHaveText(
+    await translate(page, 'hakemus.editori.paatos.kopioi'),
+  );
+
+  await editori.fill('Muokattu päätösteksti');
+  await saveButton.click();
+  await expect(vahvistaButton).toHaveText(
+    await translate(page, 'hakemus.editori.paatos.vahvista'),
+  );
+  await expect(vahvistettuAikaleima).toBeHidden();
 });
 
 test('Päätöstekstin tallennuksen epäonnistuessa näytetään virhetoast', async ({

--- a/tutu-frontend/playwright/mocks.ts
+++ b/tutu-frontend/playwright/mocks.ts
@@ -613,6 +613,11 @@ export const mockPaatosteksti = (
           string,
           unknown
         >;
+        if (route.request().url().includes('/vahvista')) {
+          putData.vahvistettu = new Date().toISOString();
+        } else {
+          putData.vahvistettu = undefined;
+        }
         await route.fulfill({
           status: 200,
           contentType: 'application/json',

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
@@ -127,7 +127,7 @@ export default function PaatosEditorPage() {
             onValitsePohja: () => setShowTekstipohjaLista(true),
           }}
         ></Editor>
-        <Stack direction="row-reverse" gap={2} justifyContent="space-between">
+        <Stack direction="row-reverse" justifyContent="space-between">
           <OphButton
             sx={{ alignSelf: 'flex-end' }}
             variant={'contained'}

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
@@ -18,13 +18,18 @@ import {
 import { TekstipohjaLista } from '@/src/components/editor/TekstipohjaLista';
 import { FullSpinner } from '@/src/components/FullSpinner';
 import { SaveRibbon } from '@/src/components/SaveRibbon';
+import { DATE_TIME_PLACEHOLDER } from '@/src/constants/constants';
 import { useShowTekstipohjat } from '@/src/context/TekstipohjaContext';
 import { usePaatosteksti } from '@/src/hooks/usePaatosteksti';
 import useToaster from '@/src/hooks/useToaster';
 import { useUnsavedChanges } from '@/src/hooks/useUnsavedChanges';
+import { formatHelsinki } from '@/src/lib/dateUtils';
 import { useTranslations } from '@/src/lib/localization/hooks/useTranslations';
 import { Paatospohja } from '@/src/lib/types/paatosteksti';
 import { handleFetchError } from '@/src/lib/utils';
+
+const copy2Clipboard = (editor: LexicalEditor) =>
+  navigator.clipboard.writeText(exportMarkdown(editor)).finally(() => {});
 
 export default function PaatosEditorPage() {
   const { t } = useTranslations();
@@ -75,6 +80,34 @@ export default function PaatosEditorPage() {
     return <FullSpinner />;
   }
 
+  const painikeAction = () => {
+    if (paatosteksti.vahvistettu) {
+      copy2Clipboard(editorRef.current!);
+      return;
+    }
+
+    showConfirmation({
+      header: t(`hakemus.editori.paatos.vahvistus.modal.otsikko`),
+      content: t(`hakemus.editori.paatos.vahvistus.modal.teksti`),
+      confirmButtonText: t(`hakemus.editori.paatos.vahvistus.modal.vahvista`),
+      handleConfirmAction: () => {
+        savePaatosteksti(
+          {
+            ...paatosteksti,
+            sisalto: exportHtml(editorRef.current),
+          },
+          true,
+          () => setHasChanges(false),
+        );
+        copy2Clipboard(editorRef.current!);
+      },
+    });
+  };
+
+  const painikkeenTeksti = paatosteksti.vahvistettu
+    ? t('hakemus.editori.paatos.kopioi')
+    : t('hakemus.editori.paatos.vahvista');
+
   return (
     <>
       <Stack
@@ -94,35 +127,30 @@ export default function PaatosEditorPage() {
             onValitsePohja: () => setShowTekstipohjaLista(true),
           }}
         ></Editor>
-        <OphButton
-          sx={{ alignSelf: 'flex-end' }}
-          variant={'contained'}
-          startIcon={<CopyAllOutlined />}
-          onClick={() =>
-            showConfirmation({
-              header: t(`hakemus.editori.paatos.vahvistus.modal.otsikko`),
-              content: t(`hakemus.editori.paatos.vahvistus.modal.teksti`),
-              confirmButtonText: t(
-                `hakemus.editori.paatos.vahvistus.modal.vahvista`,
-              ),
-              handleConfirmAction: () => {
-                savePaatosteksti(
-                  {
-                    ...paatosteksti,
-                    sisalto: exportHtml(editorRef.current),
-                  },
-                  true,
-                  () => setHasChanges(false),
-                );
-                navigator.clipboard
-                  .writeText(exportMarkdown(editorRef.current))
-                  .finally(() => {});
-              },
-            })
-          }
-        >
-          {t('hakemus.editori.paatos.vahvista')}
-        </OphButton>
+        <Stack direction="row-reverse" gap={2} justifyContent="space-between">
+          <OphButton
+            sx={{ alignSelf: 'flex-end' }}
+            variant={'contained'}
+            startIcon={<CopyAllOutlined />}
+            onClick={painikeAction}
+            data-testid={'vahvista-kopioi-painike'}
+          >
+            {painikkeenTeksti}
+          </OphButton>
+          {paatosteksti.vahvistettu && (
+            <OphTypography
+              variant={'body1'}
+              data-testid="vahvistettu-aikaleima"
+            >
+              {t(`hakemus.editori.paatos.vahvistettu`, {
+                date: formatHelsinki(
+                  paatosteksti.vahvistettu,
+                  DATE_TIME_PLACEHOLDER,
+                ),
+              })}
+            </OphTypography>
+          )}
+        </Stack>
       </Stack>
       <SaveRibbon
         onSave={onSave}

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/components/VahvistettuList.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/components/VahvistettuList.tsx
@@ -94,7 +94,6 @@ export const VahvistettuList = ({
       </OphTypography>
       <VahvistettuViestiModal
         t={t}
-        theme={theme}
         open={isModalOpen}
         viestiMetadata={viestiInModal}
         handleClose={closeModal}

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/components/VahvistettuViestiModal.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/viesti/components/VahvistettuViestiModal.tsx
@@ -3,7 +3,6 @@ import CloseIcon from '@mui/icons-material/Close';
 import { Divider, Stack, styled } from '@mui/material';
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
-import { Theme } from '@mui/material/styles';
 import {
   OphButton,
   ophColors,
@@ -34,6 +33,8 @@ const style = {
 
 const ViestiContent = styled(Box)({
   whiteSpace: 'pre-line',
+  flex: 1,
+  maxHeight: '80vh',
   overflowY: 'auto',
 });
 
@@ -44,7 +45,6 @@ export type ViestiMetadata = {
 
 export type VahvistettuViestiModalProps = {
   t: TFunction;
-  theme: Theme;
   open: boolean;
   viestiMetadata?: ViestiMetadata;
   handleClose: () => void;
@@ -65,7 +65,6 @@ const handleCopy = (html: string, t: TFunction, addToast: AddToastCallback) => {
 
 export const VahvistettuViestiModal = ({
   t,
-  theme,
   open,
   viestiMetadata,
   handleClose,
@@ -86,7 +85,7 @@ export const VahvistettuViestiModal = ({
   const content = isLoading ? (
     <FullSpinner />
   ) : (
-    <Stack gap={theme.spacing(2)}>
+    <Stack gap={2}>
       <OphTypography data-testid="viesti-otsikko" variant={'h2'}>
         {viesti?.otsikko}
       </OphTypography>

--- a/tutu-frontend/src/components/editor/TekstipohjaLista.tsx
+++ b/tutu-frontend/src/components/editor/TekstipohjaLista.tsx
@@ -113,7 +113,7 @@ const ListaSisalto = ({
           <OphTypography variant="h3">
             {`${kategoriaIndex + 1}. ${kategoria.kategoriaNimi}`}
           </OphTypography>
-          {R.map(kategoria.pohjat, (pohja, pohjaIndex) => (
+          {R.map(kategoria.pohjat || [], (pohja, pohjaIndex) => (
             <OphButton
               key={`pohjaItem_${pohjaIndex}`}
               onClick={() => {


### PR DESCRIPTION
- Kun vahvistettua päätöstekstiä muokataan ja tallennetaan, siirtyy se takaisin muokkaamaton-tilaan. 
- Jatkossa vahvistettua viestiä ei voi vahvistaa uudelleen, vastaava painike ainoastaan kopioi sisällön leikepöydälle
- Editorin alapuolelle lisätty tekstikenttä, joka kertoo vahvistetun viestin vahvistus-aikaleiman
- Lisätty viestien käsittelyssä vahvistetun viestin modaaliin vierityspalkki
- Korjattu tekstipohjalistassa bugi, joka joissain tilanteissa aiheutti sovelluksen jumittamisen renderöinnissä