### PR TITLE
OPHTUTU-379: Muutettu päätöstekstin tallennuslogiikkaa, lisätty kielitieto päätöstekstiin

### DIFF
--- a/tutu-backend/src/main/resources/db/migration/V202606161303000__add_kieli_to_paatosteksti.sql
+++ b/tutu-backend/src/main/resources/db/migration/V202606161303000__add_kieli_to_paatosteksti.sql
@@ -1,0 +1,14 @@
+ALTER TABLE paatosteksti ADD COLUMN IF NOT EXISTS kieli kieli;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'paatosteksti_kieli_check'
+    ) THEN
+        ALTER TABLE paatosteksti
+        ADD CONSTRAINT paatosteksti_kieli_check
+        CHECK (kieli IN ('fi', 'sv'));
+END IF;
+END $$;

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/PaatosController.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/controller/PaatosController.scala
@@ -2,15 +2,8 @@ package fi.oph.tutu.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.oph.tutu.backend.domain.{HakemusOid, Paatos, Paatosteksti}
-import fi.oph.tutu.backend.service.{PaatosService, UserService}
-import fi.oph.tutu.backend.utils.AuditOperation.{
-  CreatePaatosteksti,
-  ReadPaatos,
-  ReadPaatosPreview,
-  ReadPaatosteksti,
-  UpdatePaatos,
-  UpdatePaatosteksti
-}
+import fi.oph.tutu.backend.service.{NotFoundException, PaatosService, UserService}
+import fi.oph.tutu.backend.utils.AuditOperation.*
 import fi.oph.tutu.backend.utils.{AuditLog, AuditUtil, ErrorMessageMapper}
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -18,7 +11,6 @@ import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.http.{HttpStatus, MediaType, ResponseEntity}
 import org.springframework.web.bind.annotation.*
 
-import java.util.UUID
 import scala.util.{Failure, Success, Try}
 
 @RestController
@@ -167,11 +159,11 @@ class PaatosController(
     Try {
       paatosService.generatePaatosTeksti(HakemusOid(hakemusOid))
     } match {
-      case Success(paatosTeksti) =>
+      case Success(paatosTekstiJaKieli) =>
         auditLog.logRead("päätös", hakemusOid, ReadPaatosPreview, request)
-        ResponseEntity.status(HttpStatus.OK).body(paatosTeksti)
+        ResponseEntity.status(HttpStatus.OK).body(paatosTekstiJaKieli._1)
       case Failure(exception) =>
-        LOG.error(s"Päätöstekstin haku epäonnistui, hakemusOid: $hakemusOid", exception)
+        LOG.error(s"Päätöstekstin generointi epäonnistui, hakemusOid: $hakemusOid", exception)
         errorMessageMapper.mapErrorMessage(exception)
     }
   }
@@ -181,7 +173,7 @@ class PaatosController(
     produces = Array(MediaType.APPLICATION_JSON_VALUE)
   )
   @Operation(
-    summary = "Hakee päätöstekstin tai palauttaa ja tallentaa tietokantaan generoidun päätöstekstipohjan",
+    summary = "Generoi tai hakee olemassaolevan päätöstekstin",
     responses = Array(
       new ApiResponse(
         responseCode = "200",
@@ -199,19 +191,10 @@ class PaatosController(
   ): ResponseEntity[Any] = {
     Try {
       val user = userService.getEnrichedUserDetails(true)
-      paatosService.haePaatosteksti(HakemusOid(hakemusOid), user.userOid)
+      paatosService.haeTaiGeneroiPaatosteksti(HakemusOid(hakemusOid), user.userOid)
     } match {
-      case Success((paatosteksti, created)) =>
-        if (created) {
-          auditLog.logCreate(
-            auditLog.getUser(request),
-            Map("hakemusOid" -> hakemusOid),
-            CreatePaatosteksti,
-            paatosteksti
-          )
-        } else {
-          auditLog.logRead("päätösteksti", hakemusOid, ReadPaatosteksti, request)
-        }
+      case Success(paatosteksti) =>
+        auditLog.logRead("päätösteksti", hakemusOid, ReadPaatosteksti, request)
         ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(paatosteksti))
       case Failure(exception) =>
         LOG.error(
@@ -223,7 +206,7 @@ class PaatosController(
   }
 
   @PutMapping(
-    path = Array("paatos/{hakemusOid}/paatosteksti/{paatostekstiId}"),
+    path = Array("paatos/{hakemusOid}/paatosteksti"),
     consumes = Array(MediaType.APPLICATION_JSON_VALUE),
     produces = Array(MediaType.APPLICATION_JSON_VALUE)
   )
@@ -235,6 +218,10 @@ class PaatosController(
         description = RESPONSE_200_DESCRIPTION
       ),
       new ApiResponse(
+        responseCode = "400",
+        description = RESPONSE_400_DESCRIPTION
+      ),
+      new ApiResponse(
         responseCode = "500",
         description = RESPONSE_500_DESCRIPTION
       )
@@ -242,7 +229,6 @@ class PaatosController(
   )
   def tallennaPaatosteksti(
     @PathVariable hakemusOid: String,
-    @PathVariable paatostekstiId: String,
     @RequestBody paatosBytes: Array[Byte],
     request: jakarta.servlet.http.HttpServletRequest
   ): ResponseEntity[Any] = {
@@ -251,25 +237,22 @@ class PaatosController(
     Try {
       paatosService.tallennaPaatosteksti(
         HakemusOid(hakemusOid),
-        UUID.fromString(paatostekstiId),
         paatosteksti,
         user.userOid
       )
     } match {
-      case Success((vanha, uusi)) =>
-        auditLog.logChanges(
-          auditLog.getUser(request),
-          Map("hakemusOid" -> hakemusOid),
-          UpdatePaatosteksti,
-          AuditUtil.getChanges(
-            Some(mapper.writeValueAsString(vanha)),
-            Some(mapper.writeValueAsString(uusi))
-          )
+      case Success(vanhaJaUusi) =>
+        auditLogTallennus(vanhaJaUusi, hakemusOid, request)
+        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(vanhaJaUusi._2))
+      case Failure(exception: NotFoundException) =>
+        LOG.error(
+          s"Päätöstekstin tallennus epäonnistui, hakemusOid: $hakemusOid ${paatosteksti.id.map(id => s", paatostekstiId: $id").getOrElse("")}",
+          exception
         )
-        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(uusi))
+        errorMessageMapper.mapErrorMessage(exception, HttpStatus.BAD_REQUEST)
       case Failure(exception) =>
         LOG.error(
-          s"Päätöstekstin tallennus epäonnistui, hakemusOid: $hakemusOid, paatostekstiId: $paatostekstiId",
+          s"Päätöstekstin tallennus epäonnistui, hakemusOid: $hakemusOid ${paatosteksti.id.map(id => s", paatostekstiId: $id").getOrElse("")}",
           exception
         )
         errorMessageMapper.mapErrorMessage(exception)
@@ -277,7 +260,7 @@ class PaatosController(
   }
 
   @PutMapping(
-    path = Array("paatos/{hakemusOid}/paatosteksti/{paatostekstiId}/vahvista"),
+    path = Array("paatos/{hakemusOid}/paatosteksti/vahvista"),
     consumes = Array(MediaType.APPLICATION_JSON_VALUE),
     produces = Array(MediaType.APPLICATION_JSON_VALUE)
   )
@@ -289,6 +272,10 @@ class PaatosController(
         description = RESPONSE_200_DESCRIPTION
       ),
       new ApiResponse(
+        responseCode = "400",
+        description = RESPONSE_400_DESCRIPTION
+      ),
+      new ApiResponse(
         responseCode = "500",
         description = RESPONSE_500_DESCRIPTION
       )
@@ -296,7 +283,6 @@ class PaatosController(
   )
   def vahvistaPaatosteksti(
     @PathVariable hakemusOid: String,
-    @PathVariable paatostekstiId: String,
     @RequestBody paatosBytes: Array[Byte],
     request: jakarta.servlet.http.HttpServletRequest
   ): ResponseEntity[Any] = {
@@ -305,12 +291,35 @@ class PaatosController(
     Try {
       paatosService.vahvistaPaatosteksti(
         HakemusOid(hakemusOid),
-        UUID.fromString(paatostekstiId),
         paatosteksti,
         user.userOid
       )
     } match {
-      case Success((vanha, uusi)) =>
+      case Success(vanhaJaUusi) =>
+        auditLogTallennus(vanhaJaUusi, hakemusOid, request)
+        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(vanhaJaUusi._2))
+      case Failure(exception: NotFoundException) =>
+        LOG.error(
+          s"Päätöstekstin vahvistus epäonnistui, hakemusOid: $hakemusOid ${paatosteksti.id.map(id => s", paatostekstiId: $id").getOrElse("")}",
+          exception
+        )
+        errorMessageMapper.mapErrorMessage(exception, HttpStatus.BAD_REQUEST)
+      case Failure(exception) =>
+        LOG.error(
+          s"Päätöstekstin vahvistus epäonnistui, hakemusOid: $hakemusOid ${paatosteksti.id.map(id => s", paatostekstiId: $id").getOrElse("")}",
+          exception
+        )
+        errorMessageMapper.mapErrorMessage(exception)
+    }
+  }
+
+  private def auditLogTallennus(
+    vanhaJaUusi: (Option[Paatosteksti], Paatosteksti),
+    hakemusOid: String,
+    request: jakarta.servlet.http.HttpServletRequest
+  ): Unit = {
+    vanhaJaUusi match {
+      case (Some(vanha), uusi) =>
         auditLog.logChanges(
           auditLog.getUser(request),
           Map("hakemusOid" -> hakemusOid),
@@ -320,13 +329,13 @@ class PaatosController(
             Some(mapper.writeValueAsString(uusi))
           )
         )
-        ResponseEntity.status(HttpStatus.OK).body(mapper.writeValueAsString(uusi))
-      case Failure(exception) =>
-        LOG.error(
-          s"Päätöstekstin vahvistus epäonnistui, hakemusOid: $hakemusOid, paatostekstiId: $paatostekstiId",
-          exception
+      case _ =>
+        auditLog.logCreate(
+          auditLog.getUser(request),
+          Map("hakemusOid" -> hakemusOid),
+          CreatePaatosteksti,
+          vanhaJaUusi._2
         )
-        errorMessageMapper.mapErrorMessage(exception)
     }
   }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Kielistetty.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Kielistetty.scala
@@ -17,4 +17,13 @@ object Kieli:
   def optionFromString(value: String): Option[Kieli] =
     if (Option(value).forall(_.isBlank)) None else Some(fromString(value))
 
+  def fiOrSvFromString(value: String): Option[Kieli] =
+    if (Option(value).forall(_.isBlank)) None
+    else
+      fromString(value) match {
+        case fi => Some(fi)
+        case sv => Some(sv)
+        case _ => throw new IllegalArgumentException(s"Virheellinen kieli: '$value', ainaostaan 'fi' tai 'sv' sallittu")
+      }
+
 type Kielistetty = Map[Kieli, String]

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Paatos.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/domain/Paatos.scala
@@ -144,12 +144,13 @@ case class Kelpoisuus(
 )
 
 case class Paatosteksti(
-  id: UUID,
+  id: Option[UUID] = None,
   hakemusId: UUID,
   sisalto: String,
   vahvistettu: Option[LocalDateTime] = None,
-  luotu: LocalDateTime,
-  luoja: String,
+  luotu: Option[LocalDateTime] = None,
+  luoja: Option[String] = None,
   muokattu: Option[LocalDateTime] = None,
-  muokkaaja: Option[String] = None
+  muokkaaja: Option[String] = None,
+  kieli: Option[Kieli] = None
 )

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/repository/PaatosRepository.scala
@@ -91,12 +91,13 @@ class PaatosRepository extends BaseResultHandlers {
 
   implicit val getPaatostekstiResult: GetResult[Paatosteksti] = GetResult(r =>
     Paatosteksti(
-      id = r.nextObject().asInstanceOf[UUID],
+      id = Some(r.nextObject().asInstanceOf[UUID]),
       hakemusId = r.nextObject().asInstanceOf[UUID],
       sisalto = r.nextString(),
+      kieli = Kieli.optionFromString(r.nextString()),
       vahvistettu = r.nextTimestampOption().map(_.toLocalDateTime),
-      luotu = r.nextTimestamp().toLocalDateTime,
-      luoja = r.nextString(),
+      luotu = Some(r.nextTimestamp().toLocalDateTime),
+      luoja = Some(r.nextString()),
       muokkaaja = r.nextStringOption(),
       muokattu = r.nextTimestampOption().map(_.toLocalDateTime)
     )
@@ -570,21 +571,21 @@ class PaatosRepository extends BaseResultHandlers {
     }
   }
 
-  def haePaatosteksti(hakemusOid: HakemusOid): Option[Paatosteksti] = {
+  def haePaatosteksti(hakemusId: UUID): Option[Paatosteksti] = {
     try {
       db.run(
         sql"""SELECT
                 id,
                 hakemus_id,
                 sisalto,
+                kieli,
                 vahvistettu,
                 luotu,
                 luoja,
                 muokkaaja,
                 muokattu
               FROM paatosteksti
-              WHERE hakemus_id IN
-                (SELECT id FROM hakemus where hakemus_oid = ${hakemusOid.toString})
+              WHERE hakemus_id = ${hakemusId.toString}::uuid
         """.as[Paatosteksti].headOption,
         "hae_paatosteksti"
       )
@@ -598,20 +599,30 @@ class PaatosRepository extends BaseResultHandlers {
     }
   }
 
-  def tallennaUusiPaatosteksti(hakemusId: UUID, sisalto: String, luoja: String): Paatosteksti = {
+  def tallennaUusiPaatosteksti(
+    hakemusId: UUID,
+    sisalto: String,
+    kieli: Option[Kieli],
+    luoja: String,
+    asetaVahvistusAikaleima: Boolean = false
+  ): Paatosteksti = {
+    val vahvistusAikaleima = if (asetaVahvistusAikaleima) "now()" else "null"
     try {
       db.run(
         sql"""INSERT INTO paatosteksti
-             (hakemus_id, sisalto, luoja)
+             (hakemus_id, sisalto, kieli, luoja, vahvistettu)
            VALUES (
              ${hakemusId.toString}::uuid,
              $sisalto,
-             $luoja
+             ${kieli.map(_.toString).orNull}::kieli,
+             $luoja,
+             #$vahvistusAikaleima
            )
            RETURNING
              id,
              hakemus_id,
              sisalto,
+             kieli,
              vahvistettu,
              luotu,
              luoja,
@@ -629,30 +640,39 @@ class PaatosRepository extends BaseResultHandlers {
     }
   }
 
-  private def paivitaPaatosteksti(paatostekstiId: UUID, paatosteksti: Paatosteksti, muokkaaja: String) =
+  private def paivitaPaatosteksti(
+    paatostekstiId: UUID,
+    paatosteksti: Paatosteksti,
+    muokkaaja: String,
+    asetaVahvistusAikaleima: Boolean = false
+  ) = {
+    val vahvistusAikaleima = if (asetaVahvistusAikaleima) "now()" else "null"
     sql"""UPDATE paatosteksti
         SET
           sisalto = ${paatosteksti.sisalto},
+          kieli = ${paatosteksti.kieli.map(_.toString).orNull}::kieli,
           muokkaaja = $muokkaaja,
-          vahvistettu = null
+          vahvistettu = #$vahvistusAikaleima
         WHERE id = ${paatostekstiId.toString}::uuid
         RETURNING
           id,
           hakemus_id,
           sisalto,
+          kieli,
           vahvistettu,
           luotu,
           luoja,
           muokkaaja,
           muokattu""".as[Paatosteksti].head
+  }
 
   def tallennaPaatosteksti(
     paatostekstiId: UUID,
     paatosteksti: Paatosteksti,
-    luojaTaiMuokkaaja: String
+    muokkaaja: String
   ): Paatosteksti = {
     try {
-      db.run(paivitaPaatosteksti(paatostekstiId, paatosteksti, luojaTaiMuokkaaja), "paivita_paatosteksti")
+      db.run(paivitaPaatosteksti(paatostekstiId, paatosteksti, muokkaaja), "paivita_paatosteksti")
     } catch {
       case e: Exception =>
         LOG.error(s"Päätöstekstin päivitys epäonnistui: $e")
@@ -663,26 +683,9 @@ class PaatosRepository extends BaseResultHandlers {
     }
   }
 
-  private def vahvistaPaatostekstiQuery(paatostekstiId: UUID, paatosteksti: Paatosteksti, muokkaaja: String) =
-    sql"""UPDATE paatosteksti
-        SET
-          sisalto = ${paatosteksti.sisalto},
-          muokkaaja = $muokkaaja,
-          vahvistettu = now()
-        WHERE id = ${paatostekstiId.toString}::uuid
-        RETURNING
-          id,
-          hakemus_id,
-          sisalto,
-          vahvistettu,
-          luotu,
-          luoja,
-          muokkaaja,
-          muokattu""".as[Paatosteksti].head
-
   def vahvistaPaatosteksti(paatostekstiId: UUID, paatosteksti: Paatosteksti, muokkaaja: String): Paatosteksti = {
     try {
-      db.run(vahvistaPaatostekstiQuery(paatostekstiId, paatosteksti, muokkaaja), "vahvista_paatosteksti")
+      db.run(paivitaPaatosteksti(paatostekstiId, paatosteksti, muokkaaja, true), "vahvista_paatosteksti")
     } catch {
       case e: Exception =>
         LOG.error(s"Päätöstekstin vahvistaminen epäonnistui: $e")

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PaatosService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PaatosService.scala
@@ -155,72 +155,118 @@ class PaatosService(
 
   def generatePaatosTeksti(
     hakemusOid: HakemusOid
-  ): String = {
-    val hakemus: Hakemus                   = hakemusService.haeHakemus(hakemusOid).get
-    val tutkinnot: Seq[Tutkinto]           = tutkintoService.haeTutkinnot(hakemusOid)
-    val ataruHakemus: Option[AtaruHakemus] = hakemuspalveluService.haeJaParsiHakemus(hakemusOid).toOption
-    val paatos: Paatos                     = haePaatos(hakemusOid).get
-    val paatosKieli: Kieli                 = {
-      findAnswerByAtaruKysymysId(Constants.ATARU_PAATOS_KIELI, ataruHakemus.get.content.answers)
-        .flatMap(Kieli.optionFromString(_))
-        .getOrElse(Kieli.fi)
+  ): (String, Kieli) = {
+    val ataruHakemus = hakemuspalveluService.haeJaParsiHakemus(hakemusOid) match {
+      case Right(ataruHakemus) => ataruHakemus
+      case Left(error)         =>
+        LOG.error(s"Ataru-hakemuksen $hakemusOid haku epäonnistui: ${error.getMessage}")
+        throw error
     }
-    val hakijanKunta = findSingleStringAnswer("home-town", ataruHakemus.get.content.answers) match {
+    val hakemus: Hakemus         = hakemusService.haeHakemus(hakemusOid).get
+    val tutkinnot: Seq[Tutkinto] = tutkintoService.haeTutkinnot(hakemusOid)
+    val paatos: Paatos           = haePaatos(hakemusOid).get
+    val paatosKieli: Kieli       =
+      findAnswerByAtaruKysymysId(Constants.ATARU_PAATOS_KIELI, ataruHakemus.content.answers)
+        .flatMap(Kieli.fiOrSvFromString)
+        .getOrElse(Kieli.fi)
+    val hakijanKunta = findSingleStringAnswer("home-town", ataruHakemus.content.answers) match {
       case Some(kunta) => kunta
       case None        => "009"
     }
     val hallintoOikeus: HallintoOikeus = hallintoOikeusService.haeHallintoOikeusByKunta(hakijanKunta)
-
-    this.paatosTekstiGenerator.generatePaatosTeksti(
-      hakemus,
-      tutkinnot,
-      paatos,
-      paatosKieli,
-      hallintoOikeus,
-      maakoodiService
+    (
+      this.paatosTekstiGenerator.generatePaatosTeksti(
+        hakemus,
+        tutkinnot,
+        paatos,
+        paatosKieli,
+        hallintoOikeus,
+        maakoodiService
+      ),
+      paatosKieli
     )
   }
 
-  def haePaatosteksti(
+  private def haeHakemus(hakemusOid: HakemusOid): DbHakemus =
+    hakemusRepository.haeHakemus(hakemusOid) match {
+      case Some(dbHakemus) => dbHakemus
+      case _               => throw NotFoundException(s"Hakemusta $hakemusOid ei löydy")
+    }
+
+  private def haeAiempiPaatosteksti(hakemusId: UUID): Option[Paatosteksti] =
+    paatosRepository.haePaatosteksti(hakemusId) match {
+      case Some(paatosteksti) => Some(paatosteksti)
+      case None               => throw NotFoundException(s"Hakemukselle $hakemusId ei löydy aiempaa päätöstekstiä")
+    }
+
+  private def haeMuokkaajaNimi(paatosteksti: Paatosteksti): Paatosteksti = {
+    val muokkaajaNimi = onrService.haeNimi(paatosteksti.muokkaaja)
+    paatosteksti.copy(muokkaaja = Some(onrService.haeNimi(paatosteksti.muokkaaja)))
+  }
+
+  def haeTaiGeneroiPaatosteksti(
     hakemusOid: HakemusOid,
     luoja: String
-  ): (Paatosteksti, Boolean) = {
-    paatosRepository.haePaatosteksti(hakemusOid) match {
-      case Some(paatosteksti) =>
-        val muokkaajaNimi: String = onrService.haeNimi(paatosteksti.muokkaaja)
-        (paatosteksti.copy(muokkaaja = Some(muokkaajaNimi)), false)
-      case None =>
-        hakemusRepository.haeHakemus(hakemusOid) match {
-          case Some(hakemus) =>
-            (paatosRepository.tallennaUusiPaatosteksti(hakemus.id, generatePaatosTeksti(hakemusOid), luoja), true)
-          case None =>
-            throw NotFoundException(s"Hakemus $hakemusOid not found")
-        }
+  ): Paatosteksti = {
+    val dbHakemus = haeHakemus(hakemusOid)
+    paatosRepository.haePaatosteksti(dbHakemus.id) match {
+      case Some(paatosteksti) => haeMuokkaajaNimi(paatosteksti)
+      case None               =>
+        val paatosTekstiJaKieli = generatePaatosTeksti(hakemusOid)
+        Paatosteksti(
+          hakemusId = dbHakemus.id,
+          sisalto = paatosTekstiJaKieli._1,
+          kieli = Some(paatosTekstiJaKieli._2)
+        )
     }
   }
 
   def tallennaPaatosteksti(
     hakemusOid: HakemusOid,
-    paatostekstiId: UUID,
     paatosteksti: Paatosteksti,
     luojaTaiMuokkaaja: String
-  ): (Paatosteksti, Paatosteksti) = {
-    val (vanhaPaatosteksti, _) = haePaatosteksti(hakemusOid, luojaTaiMuokkaaja)
-    val uusiPaatosteksti       = paatosRepository.tallennaPaatosteksti(paatostekstiId, paatosteksti, luojaTaiMuokkaaja)
-    val muokkaajaNimi: String  = onrService.haeNimi(uusiPaatosteksti.muokkaaja)
-    (vanhaPaatosteksti, uusiPaatosteksti.copy(muokkaaja = Some(muokkaajaNimi)))
+  ): (Option[Paatosteksti], Paatosteksti) = {
+    val dbHakemus = haeHakemus(hakemusOid)
+    paatosteksti.id match {
+      case Some(id) =>
+        val uusiPaatosteksti = paatosRepository.tallennaPaatosteksti(id, paatosteksti, luojaTaiMuokkaaja)
+        (haeAiempiPaatosteksti(dbHakemus.id), haeMuokkaajaNimi(uusiPaatosteksti))
+
+      case _ =>
+        val uusiPaatosteksti =
+          paatosRepository.tallennaUusiPaatosteksti(
+            dbHakemus.id,
+            paatosteksti.sisalto,
+            paatosteksti.kieli,
+            luojaTaiMuokkaaja
+          )
+        (None, uusiPaatosteksti)
+    }
   }
 
   def vahvistaPaatosteksti(
     hakemusOid: HakemusOid,
-    paatostekstiId: UUID,
     paatosteksti: Paatosteksti,
     luojaTaiMuokkaaja: String
-  ): (Paatosteksti, Paatosteksti) = {
-    val (vanhaPaatosteksti, _) = haePaatosteksti(hakemusOid, luojaTaiMuokkaaja)
-    val uusiPaatosteksti       = paatosRepository.vahvistaPaatosteksti(paatostekstiId, paatosteksti, luojaTaiMuokkaaja)
+  ): (Option[Paatosteksti], Paatosteksti) = {
+    val dbHakemus                             = haeHakemus(hakemusOid)
+    val (vanhaPaatosteksti, uusiPaatosteksti) = paatosteksti.id match {
+      case Some(id) =>
+        val uusiPaatosteksti = paatosRepository.vahvistaPaatosteksti(id, paatosteksti, luojaTaiMuokkaaja)
+        (haeAiempiPaatosteksti(dbHakemus.id), haeMuokkaajaNimi(uusiPaatosteksti))
+
+      case _ =>
+        val uusiPaatosteksti =
+          paatosRepository.tallennaUusiPaatosteksti(
+            dbHakemus.id,
+            paatosteksti.sisalto,
+            paatosteksti.kieli,
+            luojaTaiMuokkaaja,
+            true
+          )
+        (None, uusiPaatosteksti)
+    }
     hakemusService.paivitaKasittelyVaiheSisaisesti(hakemusOid, luojaTaiMuokkaaja)
-    val muokkaajaNimi: String = onrService.haeNimi(uusiPaatosteksti.muokkaaja)
-    (vanhaPaatosteksti, uusiPaatosteksti.copy(muokkaaja = Some(muokkaajaNimi)))
+    (vanhaPaatosteksti, uusiPaatosteksti)
   }
 }

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/PerusteluService.scala
@@ -113,7 +113,6 @@ class PerusteluService(
     (currentPerustelu, newPerustelu)
   }
 
-  def haePerustelumuistio(hakemusOid: HakemusOid): Option[String] = {
+  def haePerustelumuistio(hakemusOid: HakemusOid): Option[String] =
     perusteluRepository.haePerustelumuistio(hakemusOid).map(_.sisalto)
-  }
 }

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/controller/PaatosControllerTest.scala
@@ -5,8 +5,16 @@ import fi.oph.tutu.backend.domain.*
 import fi.oph.tutu.backend.domain.Direktiivitaso.{a_1384_2015_patevyystaso_1, b_1384_2015_patevyystaso_2}
 import fi.oph.tutu.backend.domain.Ratkaisutyyppi.PeruutusTaiRaukeaminen
 import fi.oph.tutu.backend.security.SecurityConstants
-import fi.oph.tutu.backend.service.{HallintoOikeusService, KoodistoService, MaakoodiService, OnrService, UserService}
+import fi.oph.tutu.backend.service.{
+  HallintoOikeusService,
+  KoodistoService,
+  MaakoodiService,
+  OnrService,
+  TranslationService,
+  UserService
+}
 import fi.oph.tutu.backend.utils.{AuditLog, AuditOperation, TutuJsonFormats}
+import fi.oph.tutu.backend.domain.Kieli.fi
 import org.json4s.jvalue2extractable
 import org.json4s.native.JsonMethods
 import org.junit.jupiter.api.*
@@ -59,6 +67,9 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
 
   @MockitoBean
   var auditLog: AuditLog = _
+
+  @MockitoBean
+  var translationService: TranslationService = _
 
   val lomakeId: Long         = 1527182
   val hakemusOid: HakemusOid = HakemusOid("1.2.246.562.11.00000000000000006666")
@@ -446,11 +457,20 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
 
   @BeforeEach
   def setupTest(): Unit = {
-    when(onrService.haeHenkilo("test user"))
+    when(
+      userService.getEnrichedUserDetails(any)
+    ).thenReturn(
+      User(
+        userOid = "1.2.246.562.24.00000000000000006666",
+        authorities = List()
+      )
+    )
+    initAtaruHakemusRequests()
+    when(onrService.haeHenkilo("1.2.246.562.24.00000000000000006666"))
       .thenReturn(
         Right(
           OnrUser(
-            oidHenkilo = "test user",
+            oidHenkilo = "1.2.246.562.24.00000000000000006666",
             kutsumanimi = "Esko",
             sukunimi = "Esittelijä",
             kansalaisuus = Seq(KansalaisuusKoodi("123")),
@@ -460,19 +480,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
           )
         )
       )
-  }
-
-  @BeforeEach
-  def initMocks(): Unit = {
-    when(
-      userService.getEnrichedUserDetails(any)
-    ).thenReturn(
-      User(
-        userOid = "test user",
-        authorities = List()
-      )
-    )
-    initAtaruHakemusRequests()
+    when(onrService.haeNimi(Some("1.2.246.562.24.00000000000000006666"))).thenReturn("Esko Esittelijä")
   }
 
   @Test
@@ -500,7 +508,7 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
     val paatosId   = paatosRepository.haePaatos(hakemusId.get).get.id
     val paatosJSON =
       paatos2Json(
-        paatos.copy(id = paatosId, luoja = Some("test user")),
+        paatos.copy(id = paatosId, luoja = Some("1.2.246.562.24.00000000000000006666")),
         "id",
         "luotu",
         "muokattu",
@@ -838,8 +846,8 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
 
   @Test
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
-  @Order(13)
-  def haePaatosTekstiTallentaaJaPalauttaaGeneroidunPaatostekstinJosPaatostekstiaEiOle(): Unit = {
+  @Order(14)
+  def haePaatostekstiPalauttaaGeneroidunPaatostekstinJosEiLoydyKannasta(): Unit = {
     // Common mocks for generation
     when(onrService.haeHenkilo("1.2.246.562.24.00000000001"))
       .thenReturn(
@@ -907,40 +915,77 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
         )
       )
 
-    assert(paatosRepository.haePaatosteksti(hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot).isEmpty)
+    assert(paatosRepository.haePaatosteksti(hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get).isEmpty)
     val result = mvc
       .perform(get(s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti"))
       .andExpect(status().isOk)
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
       .andExpect(jsonPath("$.sisalto").value(startsWith("<p>")))
+      .andExpect(jsonPath("$.kieli").value("fi"))
       .andExpect(jsonPath("$.muokkaaja").isEmpty)
       .andExpect(jsonPath("$.muokattu").isEmpty)
       .andExpect(jsonPath("$.vahvistettu").isEmpty)
       .andReturn()
 
-    assert(paatosRepository.haePaatosteksti(hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot).isDefined)
+    verify(auditLog, times(1)).logRead(any(), any(), eqTo(AuditOperation.ReadPaatosteksti), any())
+    reset(auditLog)
+  }
 
+  @Test
+  @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
+  @Order(15)
+  def tallennaPaatostekstiLisaaUudenTekstinJosEiLoydyKannasta(): Unit = {
+    val paatostekstiJson = s"""{
+      "hakemusId": "${hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get}",
+      "sisalto": "<p>Uusi päätösteksti</p>",
+      "kieli": "sv"
+    }"""
+
+    mvc
+      .perform(
+        put(
+          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti"
+        )
+          .`with`(csrf())
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(paatostekstiJson)
+      )
+      .andExpect(status().isOk)
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(jsonPath("$.sisalto").value("<p>Uusi päätösteksti</p>"))
+      .andExpect(jsonPath("$.kieli").value("sv"))
+      .andExpect(jsonPath("$.luoja").isString)
+      .andExpect(jsonPath("$.luotu").isString)
+      .andExpect(jsonPath("$.muokkaaja").isEmpty)
+      .andExpect(jsonPath("$.muokattu").isEmpty)
+      .andExpect(jsonPath("$.vahvistettu").isEmpty)
+      .andReturn()
+
+    assert(paatosRepository.haePaatosteksti(hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get).isDefined)
     verify(auditLog, times(1)).logCreate(any(), any(), eqTo(AuditOperation.CreatePaatosteksti), any())
     reset(auditLog)
   }
 
   @Test
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
-  @Order(14)
-  def tallennaPaatosPaivittaaSisallon(): Unit = {
-    val paatosteksti = paatosRepository.haePaatosteksti(hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot)
-    val result       = mvc
+  @Order(16)
+  def tallennaPaatostekstiPaivittaaSisallonJosTekstiJoKannassa(): Unit = {
+    val paatosteksti =
+      paatosRepository.haePaatosteksti(hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get)
+    mvc
       .perform(
         put(
-          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti/${paatosteksti.get.id}"
+          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti"
         )
           .`with`(csrf())
           .contentType(MediaType.APPLICATION_JSON)
-          .content(mapper.writeValueAsString(paatosteksti.get.copy(sisalto = "Muokattu sisältö")))
+          .content(mapper.writeValueAsString(paatosteksti.get.copy(sisalto = "Muokattu sisältö", kieli = Some(fi))))
       )
       .andExpect(status().isOk)
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
       .andExpect(jsonPath("$.sisalto").value("Muokattu sisältö"))
+      .andExpect(jsonPath("$.kieli").value("fi"))
+      .andExpect(jsonPath("$.muokkaaja").isString)
       .andExpect(jsonPath("$.muokattu").isString)
       .andExpect(jsonPath("$.vahvistettu").isEmpty)
       .andReturn()
@@ -951,13 +996,67 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
 
   @Test
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
-  @Order(15)
-  def vahvistaPaatosPaivittaaSisallonJaLisaaVahvistusAikaleiman(): Unit = {
-    val paatosteksti = paatosRepository.haePaatosteksti(hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot)
-    val result       = mvc
+  @Order(17)
+  def haePaatostekstiPalauttaaKannassaOlevanJosLoytyy(): Unit = {
+    val result = mvc
+      .perform(get(s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti"))
+      .andExpect(status().isOk)
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(jsonPath("$.sisalto").value("Muokattu sisältö"))
+      .andExpect(jsonPath("$.kieli").value("fi"))
+      .andExpect(jsonPath("$.muokkaaja").isString)
+      .andExpect(jsonPath("$.muokattu").isString)
+      .andExpect(jsonPath("$.vahvistettu").isEmpty)
+      .andReturn()
+
+    verify(auditLog, times(1)).logRead(any(), any(), eqTo(AuditOperation.ReadPaatosteksti), any())
+    reset(auditLog)
+  }
+
+  @Test
+  @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
+  @Order(18)
+  def vahvistaPaatosLuoUudenSisallonJaLisaaVahvistusAikaleimanJosEiLoydyKannasta(): Unit = {
+    val paatostekstiJson =
+      s"""{
+      "hakemusId": "${hakemusIdWithPaatosTiedotJaKelpoisuudet.get}",
+      "sisalto": "<p>Uusi vahvistettu päätösteksti</p>"
+    }"""
+
+    mvc
       .perform(
         put(
-          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti/${paatosteksti.get.id}/vahvista"
+          s"/api/paatos/$hakemusOidWithPaatosTiedotJaKelpoisuudet/paatosteksti/vahvista"
+        )
+          .`with`(csrf())
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(paatostekstiJson)
+      )
+      .andExpect(status().isOk)
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(jsonPath("$.sisalto").value("<p>Uusi vahvistettu päätösteksti</p>"))
+      .andExpect(jsonPath("$.luoja").isString)
+      .andExpect(jsonPath("$.luotu").isString)
+      .andExpect(jsonPath("$.muokkaaja").isEmpty)
+      .andExpect(jsonPath("$.muokattu").isEmpty)
+      .andExpect(jsonPath("$.vahvistettu").isString)
+      .andReturn()
+
+    assert(paatosRepository.haePaatosteksti(hakemusIdWithPaatosTiedotJaKelpoisuudet.get).isDefined)
+    verify(auditLog, times(1)).logCreate(any(), any(), eqTo(AuditOperation.CreatePaatosteksti), any())
+    reset(auditLog)
+  }
+
+  @Test
+  @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
+  @Order(19)
+  def vahvistaPaatosPaivittaaSisallonJaLisaaVahvistusAikaleimanJosTekstiJoKannassa(): Unit = {
+    val paatosteksti =
+      paatosRepository.haePaatosteksti(hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get)
+    val result = mvc
+      .perform(
+        put(
+          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti/vahvista"
         )
           .`with`(csrf())
           .contentType(MediaType.APPLICATION_JSON)
@@ -976,15 +1075,15 @@ class PaatosControllerTest extends IntegrationTestBase with TutuJsonFormats {
 
   @Test
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_ESITTELIJA_FULL))
-  @Order(16)
+  @Order(20)
   def haePaatosPalauttaaVahvistetunPaatoksen(): Unit = {
     val paatosteksti = paatosRepository
-      .haePaatosteksti(hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot)
+      .haePaatosteksti(hakemusIdWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot.get)
 
     mvc
       .perform(
         put(
-          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti/${paatosteksti.get.id}/vahvista"
+          s"/api/paatos/$hakemusOidWithPaatosTiedotJaRinnastettavatTutkinnotTaiOpinnot/paatosteksti/vahvista"
         )
           .`with`(csrf())
           .contentType(MediaType.APPLICATION_JSON)

--- a/tutu-frontend/playwright/editori.paatos.spec.ts
+++ b/tutu-frontend/playwright/editori.paatos.spec.ts
@@ -9,6 +9,7 @@ import {
   mockHakemus,
   mockPaatos,
   mockPaatosteksti,
+  mockTekstipohjanValinta,
 } from '@/playwright/mocks';
 
 test.beforeEach(async ({ page }) => {
@@ -39,7 +40,7 @@ test('Muokkauksesta lähetetään PUT -kutsu backendille', async ({ page }) => {
 
   await expectRequestData(
     page,
-    '/paatosteksti/paatosteksti-id',
+    '/paatosteksti',
     page.getByTestId('editor-content-editable').fill('Muokattu päätösteksti'),
     {
       sisalto:
@@ -71,8 +72,7 @@ test('Päätöstekstin vahvistamisesta lähetetään PUT -kutsu backendille', as
   const [request] = await Promise.all([
     page.waitForRequest(
       (req) =>
-        req.url().includes('/paatosteksti/paatosteksti-id/vahvista') &&
-        req.method() === 'PUT',
+        req.url().includes('/paatosteksti/vahvista') && req.method() === 'PUT',
     ),
     page.getByTestId('modal-confirm-button').click(),
   ]);
@@ -117,22 +117,34 @@ test('Vahvistetun päätöstekstin tallennus palauttaa tekstin vahvistamattomaks
   await expect(vahvistettuAikaleima).toBeHidden();
 });
 
+test('Päätöspohjan valinnan yhteydessä sisältö liitetään editorissa näkyvään tekstiin', async ({
+  page,
+}) => {
+  await mockTekstipohjanValinta(page, 'paatospohja');
+  await page.getByTestId('add-tekstipohja-button').click();
+  await expect(page.getByTestId('tekstipohja-lista')).toBeVisible();
+
+  const sisaltoContainer = page.getByTestId('tekstipohja-lista-sisalto');
+  const firstPohjaButton = sisaltoContainer
+    .locator(':scope > *')
+    .nth(0)
+    .locator(':scope > *')
+    .nth(1);
+  await firstPohjaButton.click();
+  await expect(page.getByTestId('editor-content-editable')).toContainText(
+    'Suomi pohjassa',
+  );
+  await expect(page.getByTestId('toast-alert')).toBeVisible();
+  await expect(page.getByTestId('toast-alert')).toHaveAttribute(
+    'data-severity',
+    'success',
+  );
+});
+
 test('Päätöstekstin tallennuksen epäonnistuessa näytetään virhetoast', async ({
   page,
 }) => {
-  await page.route(
-    '**/tutu-backend/api/paatos/1.2.246.562.11.00000000001/paatosteksti/paatosteksti-id**',
-    async (route) => {
-      await route.fulfill({
-        status: 500,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          message: 'tallennusvirhe',
-        }),
-      });
-    },
-  );
-
+  await mockPaatosteksti(page, undefined, true);
   await page
     .getByTestId('editor-content-editable')
     .fill('Muokattu paatosteksti');

--- a/tutu-frontend/playwright/fixtures/tekstipohjat/_tekstipohjatKategorioittain.ts
+++ b/tutu-frontend/playwright/fixtures/tekstipohjat/_tekstipohjatKategorioittain.ts
@@ -1,6 +1,6 @@
 import { KategorianTekstipohjat } from '@/src/lib/types/viesti';
 
-export const _viestipohjatKategorioittain: KategorianTekstipohjat[] = [
+export const _tekstipohjatKategorioittain: KategorianTekstipohjat[] = [
   {
     kategoriaNimi: 'Ennakkotiedot',
     pohjat: [

--- a/tutu-frontend/playwright/fixtures/tekstipohjat/index.ts
+++ b/tutu-frontend/playwright/fixtures/tekstipohjat/index.ts
@@ -1,0 +1,6 @@
+import { _tekstipohjatKategorioittain } from '@/playwright/fixtures/tekstipohjat/_tekstipohjatKategorioittain';
+import { KategorianTekstipohjat } from '@/src/lib/types/viesti';
+
+export const mockTekstipohjatKategorioittain = (): KategorianTekstipohjat[] => {
+  return _tekstipohjatKategorioittain;
+};

--- a/tutu-frontend/playwright/fixtures/viestipohjat/index.ts
+++ b/tutu-frontend/playwright/fixtures/viestipohjat/index.ts
@@ -1,6 +1,0 @@
-import { _viestipohjatKategorioittain } from '@/playwright/fixtures/viestipohjat/_viestipohjatKategorioittain';
-import { KategorianTekstipohjat } from '@/src/lib/types/viesti';
-
-export const mockViestipohjatKategorioittain = (): KategorianTekstipohjat[] => {
-  return _viestipohjatKategorioittain;
-};

--- a/tutu-frontend/playwright/mocks.ts
+++ b/tutu-frontend/playwright/mocks.ts
@@ -7,8 +7,8 @@ import { sortBy } from 'remeda';
 import { getLiitteet } from '@/playwright/fixtures/hakemus1';
 import { getLopullinenHakemus } from '@/playwright/fixtures/hakemus2';
 import { getPaatos } from '@/playwright/fixtures/paatos1';
+import { mockTekstipohjatKategorioittain } from '@/playwright/fixtures/tekstipohjat';
 import { getMockTutkinnot } from '@/playwright/fixtures/tutkinnot';
-import { mockViestipohjatKategorioittain } from '@/playwright/fixtures/viestipohjat';
 import { Language } from '@/src/lib/localization/localizationTypes';
 import { Hakemus } from '@/src/lib/types/hakemus';
 import {
@@ -599,11 +599,13 @@ const defaultPaatosteksti: Paatosteksti = {
   luoja: 'Lauri Luoja',
   sisalto:
     '<p><span style="white-space: pre-wrap;">Päätosteksti sisältö</span></p>',
+  kieli: 'fi',
 };
 
 export const mockPaatosteksti = (
   page: Page,
   paatosteksti?: Partial<Paatosteksti>,
+  modifyFails: boolean = false,
 ) => {
   return page.route(
     '**/tutu-backend/api/paatos/1.2.246.562.11.00000000001/paatosteksti**',
@@ -619,9 +621,9 @@ export const mockPaatosteksti = (
           putData.vahvistettu = undefined;
         }
         await route.fulfill({
-          status: 200,
+          status: modifyFails ? 500 : 200,
           contentType: 'application/json',
-          body: JSON.stringify(putData),
+          body: JSON.stringify(modifyFails ? { message: 'ei onnaa' } : putData),
         });
       } else {
         await route.fulfill({
@@ -837,13 +839,14 @@ export const mockTekstipohjaKategoriat = (
   );
 };
 
-export const mockViestipohjanValinta = (
+export const mockTekstipohjanValinta = (
   page: Page,
+  pohjatyyppi: 'viestipohja' | 'paatospohja',
   listaFails: boolean = false,
   sisaltoFails: boolean = false,
 ) => {
   return page.route(
-    '**/tutu-backend/api/viestipohja/**',
+    `**/tutu-backend/api/${pohjatyyppi}/**`,
     async (route: Route) => {
       if (route.request().url().endsWith('kategorioittain')) {
         await route.fulfill({
@@ -852,11 +855,11 @@ export const mockViestipohjanValinta = (
           body: JSON.stringify(
             listaFails
               ? { message: 'ei onnaa' }
-              : mockViestipohjatKategorioittain(),
+              : mockTekstipohjatKategorioittain(),
           ),
         });
       } else {
-        const viestipohja: Viestipohja = {
+        const tekstipohja: Viestipohja | Paatospohja = {
           ...MOCK_TEKSTIPOHJA,
           sisalto: {
             fi: 'Suomi pohjassa',
@@ -867,7 +870,7 @@ export const mockViestipohjanValinta = (
           status: sisaltoFails ? 500 : 200,
           contentType: 'application/json',
           body: JSON.stringify(
-            sisaltoFails ? { message: 'ei onnaa' } : viestipohja,
+            sisaltoFails ? { message: 'ei onnaa' } : tekstipohja,
           ),
         });
       }

--- a/tutu-frontend/playwright/viesti.pohjanValinta.spec.ts
+++ b/tutu-frontend/playwright/viesti.pohjanValinta.spec.ts
@@ -7,7 +7,7 @@ import {
   mockUser,
   mockViestiLista,
   mockViestiOletussisalto,
-  mockViestipohjanValinta,
+  mockTekstipohjanValinta,
   mockViestiTyoversio,
   viestiTyoversio,
 } from '@/playwright/mocks';
@@ -28,7 +28,7 @@ test.beforeEach(async ({ page }) => {
 test('Viestipohjalista avautuu ja sulkeutuu onnistuneesti, olemassaolevat pohjat näkyvät listalla', async ({
   page,
 }) => {
-  await mockViestipohjanValinta(page);
+  await mockTekstipohjanValinta(page, 'viestipohja');
   const addPohjaButton = page.getByTestId('add-tekstipohja-button');
   await expect(addPohjaButton).toBeVisible();
   await addPohjaButton.click();
@@ -62,7 +62,7 @@ test('Viestipohjalista avautuu ja sulkeutuu onnistuneesti, olemassaolevat pohjat
 test('Viestipohjan valinnan yhteydessä sisältö liitetään editorissa näkyvään tekstiin', async ({
   page,
 }) => {
-  await mockViestipohjanValinta(page);
+  await mockTekstipohjanValinta(page, 'viestipohja');
   await page.getByTestId('add-tekstipohja-button').click();
   await expect(page.getByTestId('tekstipohja-lista')).toBeVisible();
 
@@ -86,7 +86,7 @@ test('Viestipohjan valinnan yhteydessä sisältö liitetään editorissa näkyv�
 test('Viestipohjalistan latauksen epäonnistuessa näytetään virheteksti', async ({
   page,
 }) => {
-  await mockViestipohjanValinta(page, true);
+  await mockTekstipohjanValinta(page, 'viestipohja', true);
   await page.getByTestId('add-tekstipohja-button').click();
 
   await expect(page.getByTestId('tekstipohja-lista')).toBeVisible();
@@ -101,7 +101,7 @@ test('Viestipohjalistan latauksen epäonnistuessa näytetään virheteksti', asy
 test('Viestipohjan latauksen epäonnistuessa näytetään virheteksti', async ({
   page,
 }) => {
-  await mockViestipohjanValinta(page, false, true);
+  await mockTekstipohjanValinta(page, 'viestipohja', false, true);
   await page.getByTestId('add-tekstipohja-button').click();
 
   await expect(page.getByTestId('tekstipohja-lista')).toBeVisible();

--- a/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/editori/paatos/page.tsx
@@ -165,17 +165,10 @@ export default function PaatosEditorPage() {
           headerText={t('tekstipohjat.paatospohjat.valitse')}
           close={() => setShowTekstipohjaLista(false)}
           selectPohja={(pohja: Paatospohja) => {
-            const pt = paatosteksti as unknown as {
-              kieli?: string;
-              kielikoodi?: string;
-            };
-            const lang = pt?.kieli || pt?.kielikoodi || 'fi';
-            const sisaltoObj = pohja.sisalto as
-              | Record<string, string>
-              | undefined;
-            const kielistettyTeksti = sisaltoObj?.[lang] ?? '';
+            const lang = paatosteksti.kieli;
+            const kielistettyTeksti = lang ? pohja.sisalto[lang] : '';
 
-            if (kielistettyTeksti && paatosteksti) {
+            if (kielistettyTeksti) {
               pasteHtml(editorRef.current, kielistettyTeksti);
               addToast({
                 key: 'tekstipohjat.paatospohjat.valittu',

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/MuuTutkintoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/MuuTutkintoComponent.tsx
@@ -35,6 +35,7 @@ export const MuuTutkintoComponent = ({
     'MUU',
     hakemus.lomakkeenKieli,
   );
+  console.log('!!!!!! läpi meni', tutkinto);
 
   const [currentTutkinto, setCurrentTutkinto] = React.useState<
     Tutkinto | undefined

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/MuuTutkintoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/components/MuuTutkintoComponent.tsx
@@ -35,8 +35,6 @@ export const MuuTutkintoComponent = ({
     'MUU',
     hakemus.lomakkeenKieli,
   );
-  console.log('!!!!!! läpi meni', tutkinto);
-
   const [currentTutkinto, setCurrentTutkinto] = React.useState<
     Tutkinto | undefined
   >(tutkinto);

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/hooks/useHakijanIlmoittamaTieto.ts
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/hooks/useHakijanIlmoittamaTieto.ts
@@ -44,7 +44,6 @@ export const useHakijanIlmoittamaTieto = (
 
     // MUU tutkinto käsitellään erikseen
     if (tutkintoJarjestys === 'MUU') {
-      console.log('!!!!!!!!!MUUUUUUUUU');
       return {
         muuTutkintoTieto: haeArvo(
           tutkintoTaiKoulutus,

--- a/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/hooks/useHakijanIlmoittamaTieto.ts
+++ b/tutu-frontend/src/app/hakemus/[oid]/tutkinnot/hooks/useHakijanIlmoittamaTieto.ts
@@ -44,6 +44,7 @@ export const useHakijanIlmoittamaTieto = (
 
     // MUU tutkinto käsitellään erikseen
     if (tutkintoJarjestys === 'MUU') {
+      console.log('!!!!!!!!!MUUUUUUUUU');
       return {
         muuTutkintoTieto: haeArvo(
           tutkintoTaiKoulutus,

--- a/tutu-frontend/src/hooks/usePaatosteksti.ts
+++ b/tutu-frontend/src/hooks/usePaatosteksti.ts
@@ -19,7 +19,7 @@ type MutateParameters = {
 };
 
 const putPaatosteksti = (hakemusOid: string, params: MutateParameters) => {
-  const url = `paatos/${hakemusOid}/paatosteksti/${params.paatosteksti.id}${params.vahvista ? `/vahvista` : ''}`;
+  const url = `paatos/${hakemusOid}/paatosteksti${params.vahvista ? `/vahvista` : ''}`;
 
   return doApiPut(url, params.paatosteksti);
 };

--- a/tutu-frontend/src/lib/types/paatosteksti.ts
+++ b/tutu-frontend/src/lib/types/paatosteksti.ts
@@ -3,10 +3,11 @@ export type Paatosteksti = {
   hakemusId: string;
   vahvistettu?: string;
   sisalto: string;
-  luotu: string;
+  luotu?: string;
   muokattu?: string;
-  luoja: string;
+  luoja?: string;
   muokkaaja?: string;
+  kieli?: 'fi' | 'sv';
 };
 
 export type Paatospohja = {


### PR DESCRIPTION
Jatkossa uusi päätösteksti tallennetaan vasta kun käyttäjä suorittaa tallennuksen. 
Lisätty logiikka päätöstekstin kielen tallentamiseen / käsittelyyn, ko. tietoa tarvitaan liitettäessä päätöspohjaa tekstiin.