### PR TITLE
OPHTUTU-492 Valintojen nollaus rinnastettavaa opintoa vaihdettaessa

### DIFF
--- a/tutu-frontend/playwright/paatos.rinnastettavatTutkinnotTaiOpinnot.spec.ts
+++ b/tutu-frontend/playwright/paatos.rinnastettavatTutkinnotTaiOpinnot.spec.ts
@@ -56,7 +56,6 @@ test('Valittaessa 4 Riittävät opinnot, tulee opintojen lisäyksen jälkeen oik
           rinnastettavatTutkinnotTaiOpinnot: [
             {
               tutkintoTaiOpinto: 'Luokanopettaja',
-              opetuskieli: 'suomi',
             },
           ],
         },

--- a/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/RinnastettavaTutkintoTaiOpintoComponent.tsx
+++ b/tutu-frontend/src/app/hakemus/[oid]/paatostiedot/components/RinnastettavaTutkintoTaiOpintoComponent.tsx
@@ -108,9 +108,16 @@ export const RinnastettavaTutkintoTaiOpintoComponent = ({
         );
 
   const updateTutkintoTaiOpintoFieldAction = (fieldVal: string) => {
+    const tobeTutkinto = { ...tutkintoTaiOpinto };
+    if (fieldVal !== null) {
+      tobeTutkinto.myonteinenPaatos = undefined;
+      tobeTutkinto.opetuskieli = undefined;
+      tobeTutkinto.kielteisenPaatoksenPerustelut = undefined;
+      tobeTutkinto.myonteisenPaatoksenLisavaatimukset = undefined;
+    }
     updateTutkintoTaiOpintoAction(
       {
-        ...tutkintoTaiOpinto,
+        ...tobeTutkinto,
         tutkintoTaiOpinto: fieldVal,
       },
       index,


### PR DESCRIPTION
OPHTUTU-492 Nollataan valinnat, kun tutkintoa vaihdetaan
OPHTUTU-492 Korjattu testi, koska tutkinnon valinta nollaa muuta valitut arvot