### PR TITLE
OPHTUTU-497 Järjestä esittelijät sukunimen mukaan

### DIFF
--- a/tutu-frontend/playwright/maajako.spec.ts
+++ b/tutu-frontend/playwright/maajako.spec.ts
@@ -252,3 +252,28 @@ test('SelectedMaakoodiInfo päivittyy kun maakoodien esittelijät muuttuvat', as
   // Tarkista että esittelijän nimi ei ole enää näkyvissä
   await expect(page.getByTestId('selected-maakoodi-esittelija')).toBeHidden();
 });
+
+test('Esittelijät on järjestetty sukunimen mukaan', async ({ page }) => {
+  setupMaakoodiApi(page, [
+    {
+      id: 'M1',
+      koodiUri: 'maatjavaltiot2_001',
+      fi: 'Suomi',
+      esittelijaId: 'E1',
+    },
+    {
+      id: 'M2',
+      koodiUri: 'maatjavaltiot2_002',
+      fi: 'Ruotsi',
+      esittelijaId: null,
+    },
+  ]);
+
+  await gotoMaajako(page);
+
+  const esittelijaSections = page.getByTestId('esittelija-section');
+  await expect(esittelijaSections).toHaveText([
+    'Janne Jamaika',
+    'Kari Karibia',
+  ]);
+});

--- a/tutu-frontend/playwright/yhteinenkasittely.spec.ts
+++ b/tutu-frontend/playwright/yhteinenkasittely.spec.ts
@@ -49,6 +49,15 @@ test('Yhteisen käsittelyn luominen', async ({ page }) => {
     'yhteinenkasittely-uusiKasittely-tyopari',
   );
   await tyopariSelect.click();
+
+  // Varmistetaan että esittäjät on sukunimen mukaan järjestettynä
+  const options = page.locator(
+    'ul[role="listbox"]:visible li[role="option"]:visible',
+  );
+  await expect(options).toHaveCount(2);
+  await expect(options.first()).toHaveText('Janne Jamaika');
+  await expect(options.nth(1)).toHaveText('Kari Karibia');
+
   const tyopariOption = page.locator(
     "xpath=//li[@data-value='1.2.246.562.24.999999999999']",
   );

--- a/tutu-frontend/src/app/maajako/components/EsittelijaSection.tsx
+++ b/tutu-frontend/src/app/maajako/components/EsittelijaSection.tsx
@@ -34,7 +34,7 @@ export const EsittelijaSection = ({
 
   return (
     <>
-      <OphTypography variant={'h4'}>
+      <OphTypography variant={'h4'} data-testid="esittelija-section">
         {esittelija.etunimi} {esittelija.sukunimi}
       </OphTypography>
 

--- a/tutu-frontend/src/hooks/useEsittelijat.ts
+++ b/tutu-frontend/src/hooks/useEsittelijat.ts
@@ -16,7 +16,12 @@ export const useEsittelijat = () => {
   } = useQuery({
     queryKey: ['getEsittelijat'],
     queryFn: getEsittelijat,
-    select: (data) => R.sortBy(data ?? [], (e) => e.sukunimi),
+    select: (data) =>
+      R.sortBy(
+        data ?? [],
+        (e) => e.sukunimi,
+        (e) => e.etunimi,
+      ),
     staleTime: Infinity,
     throwOnError: false,
   });

--- a/tutu-frontend/src/hooks/useEsittelijat.ts
+++ b/tutu-frontend/src/hooks/useEsittelijat.ts
@@ -16,6 +16,7 @@ export const useEsittelijat = () => {
   } = useQuery({
     queryKey: ['getEsittelijat'],
     queryFn: getEsittelijat,
+    select: (data) => R.sortBy(data ?? [], (e) => e.sukunimi),
     staleTime: Infinity,
     throwOnError: false,
   });
@@ -25,14 +26,11 @@ export const useEsittelijat = () => {
   const selectOptions =
     isLoading || error
       ? []
-      : R.map(
-          R.sortBy(uniqueEsittelijat, (esittelija) => esittelija.etunimi),
-          (esittelija) => ({
-            value: esittelija.esittelijaOid,
-            label: `${esittelija.etunimi} ${esittelija.sukunimi}`,
-            ...(esittelija.id ? { id: esittelija.id } : {}),
-          }),
-        );
+      : R.map(uniqueEsittelijat, (esittelija) => ({
+          value: esittelija.esittelijaOid,
+          label: `${esittelija.etunimi} ${esittelija.sukunimi}`,
+          ...(esittelija.id ? { id: esittelija.id } : {}),
+        }));
 
   return { data, isLoading, options: selectOptions, error };
 };


### PR DESCRIPTION
Jos haluatte tästä monikäyttöisemmän, niin voin pistää tuon select function parameterina hookille. Ajattelin mennä tällä koska sama järjestys halutaan kaikkialle.

En välttämättä kovakoodaisi noita nimiä suoraan testeihin, mutta ei oikeastaan vaikuttanut ihan suoraviivaiselta miten nuo sukunimet saisi ulos nätisti. Mitä luin niin allTextContent() voi olla flaky, ja sitä ei ole muuallakaan testeissä käytetty, joten jätin nyt tämmöiseksi. Saa ehdottaa parannuksia.

Ja tosiaan tämähän ei nyt hanskaa casea jossa kahdella esittelijällä on sama sukunimi. Pitäisikö secondaryna sortata etunimen mukaan?