### PR TITLE
OPHTUTU-476: Refaktoroitu liitteiden aikaleimojen käsittelyä

### DIFF
--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/HakemuspalveluService.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/service/HakemuspalveluService.scala
@@ -3,7 +3,7 @@ package fi.oph.tutu.backend.service
 import fi.oph.tutu.backend.TutuBackendApplication.CALLER_ID
 import fi.oph.tutu.backend.domain.*
 import fi.oph.tutu.backend.utils.TutuJsonFormats
-import fi.oph.tutu.backend.utils.Utility.toLocalDateTime
+import fi.oph.tutu.backend.utils.Utility.{toLocalDateTime, toUtcDateTime}
 import fi.vm.sade.javautils.nio.cas.{CasClient, CasClientBuilder, CasConfig}
 import org.json4s.*
 import org.json4s.jackson.JsonMethods.*
@@ -146,7 +146,7 @@ class HakemuspalveluService(httpService: HttpService) extends TutuJsonFormats {
         rawItems.flatMap(item => {
           val fields    = item.asInstanceOf[JObject].values
           val time      = (item \ "time").extract[String]
-          val localTime = toLocalDateTime(time)
+          val localTime = toUtcDateTime(time)
 
           val keysOfModifiedFields = fields.keys.toSeq.diff(COMMON_MUUTOSHISTORIA_FIELDS)
           keysOfModifiedFields.flatMap(key =>

--- a/tutu-backend/src/main/scala/fi/oph/tutu/backend/utils/Utility.scala
+++ b/tutu-backend/src/main/scala/fi/oph/tutu/backend/utils/Utility.scala
@@ -11,6 +11,9 @@ object Utility {
   def toLocalDateTime(dateTime: String): LocalDateTime =
     ZonedDateTime.parse(dateTime).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime
 
+  def toUtcDateTime(dateTime: String): ZonedDateTime =
+    ZonedDateTime.parse(dateTime).withZoneSameInstant(ZoneOffset.UTC)
+
   def toPrecision(value: Double, precision: Int): Double =
     BigDecimal(value).setScale(precision, BigDecimal.RoundingMode.HALF_UP).toDouble
 

--- a/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/HakemuspalveluServiceTest.scala
+++ b/tutu-backend/src/test/scala/fi/oph/tutu/backend/service/HakemuspalveluServiceTest.scala
@@ -33,7 +33,7 @@ class HakemuspalveluServiceTest extends UnitTestBase {
     )
     val muutosHistoria = hakemuspalveluService.resolveLiitteidenMuutoshistoria(loadJson("muutosHistoria.json"))
     assertEquals(8, muutosHistoria.size)
-    fileIdsWithTimestamp1.foreach(id => assertEquals("2025-06-17T10:02:20.473", muutosHistoria(id)))
-    fileIdsWithTimestamp2.foreach(id => assertEquals("2025-10-16T06:33:02.234580", muutosHistoria(id)))
+    fileIdsWithTimestamp1.foreach(id => assertEquals("2025-06-17T10:02:20.473Z", muutosHistoria(id)))
+    fileIdsWithTimestamp2.foreach(id => assertEquals("2025-10-16T06:33:02.234580Z", muutosHistoria(id)))
   }
 }


### PR DESCRIPTION
Refaktoroitu liitteiden aikaleimojen käsittelyä backendissa niin että aikavyöhyketieto (UTC) on mukana. Tällöin ne näkyvät käyttöliittymän puolella oikein.