### PR TITLE
OPHTUTU-498: Vaihdettu uusiVastaus viestin tila teksti

### DIFF
--- a/tutu-frontend/src/app/yhteinenKasittely/MessageRow.tsx
+++ b/tutu-frontend/src/app/yhteinenKasittely/MessageRow.tsx
@@ -66,7 +66,7 @@ export default function MessageRow({
         variant="body1"
         data-testid={'viestin-status-uusi-vastaus'}
       >
-        {t('yhteinenKasittely.vastattu')}
+        {t('yhteinenKasittely.vastausSaapunut')}
       </OphTypography>
       <OphTypography
         variant="body1"


### PR DESCRIPTION
Lähetetyn yhteiskäsittelyviestin tila teksti muutettu "Vastattu" -> "Vastaus Saapunut", jos siihen on tullut uusi vastaus.